### PR TITLE
Added missing Tokyo Night highlighting color

### DIFF
--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -11,7 +11,13 @@ RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Highlight colors
-tmux set -g mode-style 'fg=#a9b1d6,bg=#292e42'
+set -g mode-style "fg=#a9b1d6,bg=#2A2F41"
+
+set -g message-style "bg=#7aa2f7,fg=#2A2F41"
+set -g message-command-style "fg=#c0caf5,bg=#2A2F41"
+
+set -g pane-border-style "fg=#2A2F41"
+set -g pane-active-border-style "fg=#7aa2f7"
 
 tmux set -g status-style bg=#1A1B26
 tmux set -g status-right-length 150

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -36,3 +36,6 @@ tmux set -g window-status-format "#[fg=#c0caf5,bg=default,none,dim]   $window
   #+--- Bars RIGHT ---+
 tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B]  %Y-%m-%d #[]❬ %H:%M $git_status$wb_git_status"
 tmux set -g window-status-separator ""
+
+# Add highlight colors for session & copy mode
+set -g mode-style bg=#a9b1d6,fg=#24283B

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -10,6 +10,8 @@
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Add highlight colors for session & copy mode
+tmux set -g mode-style 'fg=#a9b1d6,bg=#292e42'
 tmux set -g status-style bg=#1A1B26
 tmux set -g status-right-length 150
 
@@ -36,6 +38,3 @@ tmux set -g window-status-format "#[fg=#c0caf5,bg=default,none,dim]   $window
   #+--- Bars RIGHT ---+
 tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B]  %Y-%m-%d #[]❬ %H:%M $git_status$wb_git_status"
 tmux set -g window-status-separator ""
-
-# Add highlight colors for session & copy mode
-set -g mode-style bg=#a9b1d6,fg=#24283B

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -10,7 +10,7 @@
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Add highlight colors for highlighting
+# Highlight colors
 tmux set -g mode-style 'fg=#a9b1d6,bg=#292e42'
 
 tmux set -g status-style bg=#1A1B26

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -10,8 +10,9 @@
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Add highlight colors for session & copy mode
+# Add highlight colors for highlighting
 tmux set -g mode-style 'fg=#a9b1d6,bg=#292e42'
+
 tmux set -g status-style bg=#1A1B26
 tmux set -g status-right-length 150
 


### PR DESCRIPTION
## Major changes

None.

## Minor changes

None.

## Bug & security fixes

- [X] Fixes #24

## Additional informations

Highlight color looks fine to me, but this is a subjective topic so this will require review & requests for changes before merging @janoamaral.

Screenshot for the session list

![image](https://github.com/janoamaral/tokyo-night-tmux/assets/18418459/156b8225-ec5f-4806-8587-7e80e1f460d3)

Screenshot for the copy-mode highlight

![image](https://github.com/janoamaral/tokyo-night-tmux/assets/18418459/6dc6b5b5-b05f-4ce6-ac9c-5f68be09ad13)