### PR TITLE
Implement support for nowplaying-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ so it's independent of terminal theme.
 - Remote branch sync indicator (you will never forget to push or pull again 🤪).
 - Great terminal icons.
 - Prefix highlight incorporated.
-- Cmus status bar
+- Now Playing status bar, supporting [cmus]/[nowplaying-cli]
 - Windows has custom pane number indicator.
 - Pane zoom mode indicator.
 - Date and time.
@@ -69,3 +69,7 @@ https://github.com/janoamaral/tokyo-night-tmux/assets/10008708/59ecd814-bc2b-47f
 Legacy tokyonight
 
 ![Snap 4](snaps/l01.png)
+
+
+[cmus]: https://cmus.github.io/
+[nowplaying-cli]: https://github.com/kirtan-shah/nowplaying-cli

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -25,7 +25,7 @@ tmux set -g status-right-length 150
 SCRIPTS_PATH="$CURRENT_DIR/src"
 PANE_BASE="$(tmux show -g | grep pane-base-index | cut -d" " -f2 | bc)"
 
-cmus_status="#($SCRIPTS_PATH/cmus-tmux-statusbar.sh)"
+cmus_status="#($SCRIPTS_PATH/music-tmux-statusbar.sh)"
 git_status="#($SCRIPTS_PATH/git-status.sh #{pane_current_path})"
 wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I -d)"


### PR DESCRIPTION
[nowplaying-cli](https://github.com/kirtan-shah/nowplaying-cli) uses macOS frameworks to gather the metadata of any playing media in supported applications (VLC, TIDAL, Spotify, Browser, etc.) The script now checks if either `cmus-remote` or `nowplaying-cli` commands are available using the POSIX method, and gathers the relevant data from either tool.

An additional integer strip using cut has been included for compatibility with bash.

## Major changes

- [x] Add support for [nowplaying-cli](https://github.com/kirtan-shah/nowplaying-cli) to music status bar