### PR TITLE
Updated shell scripts to all use hashbang /usr/bin/env bash

### DIFF
--- a/src/custom-number.sh
+++ b/src/custom-number.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 ID=$(($1))
 FORMAT=$2
 

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -1,4 +1,5 @@
-#!/bin/env bash
+#!/usr/bin/env bash
+
 cd $1
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Value parser for nowplaying-cli
 parse_npcli_value() {

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 cd $1
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)


### PR DESCRIPTION
This fixes an issue on mac where some of the scripts would error out as `/bin/env` does not exist on osx by default.

`/usr/bin/env` exists, so this updates all the shell scripts to use that instead.