### PR TITLE
Add netspeed widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This theme requires the use of a patched font with Nerd Font. Ensure your termin
 This theme requires the Noto fonts to be installed on your operating system. Make sure your operating system has the needed font and is configured to use one.
 
 ### GNU bc
-This theme requires the [`GNU bc`](https://www.gnu.org/software/bc/) for precise mathematical calculation of network speed, [Tokyo-night-tmux](https://janoamaral/tokyo-night-tmux) also shows the real time network speed in right side of status bar.
+This theme requires the [`GNU bc`](https://www.gnu.org/software/bc/) for precise mathematical calculation of network speed, [Tokyo-night-tmux](https://github.com/janoamaral/tokyo-night-tmux) also shows the real time network speed in right side of status bar.
 
 ```bash
 pacman -S bc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ This theme requires the use of a patched font with Nerd Font. Ensure your termin
 
 This theme requires the Noto fonts to be installed on your operating system. Make sure your operating system has the needed font and is configured to use one.
 
-### Installation using TPM
+### GNU bc
+This theme requires the [`GNU bc`](https://www.gnu.org/software/bc/) for precise mathematical calculation of network speed, [Tokyo-night-tmux](https://janoamaral/tokyo-night-tmux) also shows the real time network speed in right side of status bar.
+
+```bash
+pacman -S bc
+```
+see documentation for installing [`GNU bc`](https://www.gnu.org/software/bc/) in other Operation system.
+
+## Installation using TPM
 
 In your `tmux.conf`:
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In your `tmux.conf`:
 set -g @plugin "janoamaral/tokyo-night-tmux"
 ```
 
-### Configuration
+## Configuration
 
 #### Number styles
 
@@ -56,8 +56,25 @@ set -g @tokyo-night-tmux_window_id_style digital
 set -g @tokyo-night-tmux_pane_id_style hsquare
 set -g @tokyo-night-tmux_zoom_id_style dsquare
 ```
+## Widgets
 
-The styles:
+For widgets add following lines in you `.tmux.conf`
+
+#### Now Playing widget
+
+```bash
+set -g @tokyo-night-tmux_show_music 1
+```
+
+#### Netspeed widget
+
+```bash
+set -g @tokyo-night-tmux_show_netspeed 1
+set -g @tokyo-night-tmux_netspeed_iface "wlan0" # your network interface, find with ip link
+```
+set variables value `0` to disable the widget, Remember to restart the `tmux` after changing values.
+
+## The styles:
 - `none`: no style, default font
 - `digital`: 7 segment number (🯰...🯹) (needs [Unicode support](https://github.com/janoamaral/tokyo-night-tmux/issues/36#issuecomment-1907072080)) 
 - `roman`: roman numbers (󱂈...󱂐) (needs nerdfont)

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -71,7 +71,7 @@ if [ -n "$DURATION" ]; then
   D_SEC=`printf '%02d' $(($DURATION % 60))`
 fi
 if [ -n "$DURATION" ] && [ -n "$POSITION" ]; then
-  # TIME="[$P_MIN:$P_SEC / $D_MIN:$D_SEC]" # hide to making space for network speed
+  TIME="[$P_MIN:$P_SEC / $D_MIN:$D_SEC]"
   if [ "$D_SEC" = "-1" ]; then
     TIME="[ $P_MIN:$P_SEC]"
   fi
@@ -82,7 +82,7 @@ if [ -n "$TITLE"  ]; then
   if [ "$STATUS" = "playing"  ]; then
     PLAY_STATE="$OUTPUT"
   else
-    PLAY_STATE="$OUTPUT"
+    PLAY_STATE="󰏤$OUTPUT"
   fi
   OUTPUT="$PLAY_STATE $TITLE"
 

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -66,7 +66,7 @@ if [ -n "$DURATION" ]; then
   D_SEC=`printf '%02d' $(($DURATION % 60))`
 fi
 if [ -n "$DURATION" ] && [ -n "$POSITION" ]; then
-  TIME="[$P_MIN:$P_SEC / $D_MIN:$D_SEC]"
+  # TIME="[$P_MIN:$P_SEC / $D_MIN:$D_SEC]" # hide to making space for network speed
   if [ "$D_SEC" = "-1" ]; then
     TIME="[ $P_MIN:$P_SEC]"
   fi
@@ -77,7 +77,7 @@ if [ -n "$TITLE"  ]; then
   if [ "$STATUS" = "playing"  ]; then
     PLAY_STATE="$OUTPUT"
   else
-    PLAY_STATE="$OUTPUT"
+    PLAY_STATE="$OUTPUT"
   fi
   OUTPUT="$PLAY_STATE $TITLE"
 

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Check the global value
+SHOW_MUSIC=$(tmux show-option -gv @tokyo-night-tmux_show_music)
+if [ "$SHOW_MUSIC" != "1" ]; then
+    exit 0
+fi
 # Value parser for nowplaying-cli
 parse_npcli_value() {
     echo "$NPCLI_STATUS" | grep "$1" | awk -F '= ' '{print $2}' | tr -d '";'

--- a/src/netspeed.sh
+++ b/src/netspeed.sh
@@ -35,24 +35,17 @@ readable_format() {
     fi
 }
 
-# Echo with truncate condition
-while true; do
-    read RX1 TX1 < <(get_bytes "$INTERFACE")
-    sleep 1
-    read RX2 TX2 < <(get_bytes "$INTERFACE")
+# Echo network speed
+read RX1 TX1 < <(get_bytes "$INTERFACE")
+sleep 1
+read RX2 TX2 < <(get_bytes "$INTERFACE")
 
-    RX_DIFF=$((RX2 - RX1))
-    TX_DIFF=$((TX2 - TX1))
+RX_DIFF=$((RX2 - RX1))
+TX_DIFF=$((TX2 - TX1))
 
-    TIME_DIFF=1
+TIME_DIFF=1
 
-    RX_SPEED=$(readable_format "$((RX_DIFF / TIME_DIFF))")
-    TX_SPEED=$(readable_format "$((TX_DIFF / TIME_DIFF))")
+RX_SPEED=$(readable_format "$((RX_DIFF / TIME_DIFF))")
+TX_SPEED=$(readable_format "$((TX_DIFF / TIME_DIFF))")
 
-    width=$(tmux display -p '#{window_width}')
-    if [ "$width" -lt 115 ]; then
-        echo "⮛ $RX_SPEED ⮙ $TX_SPEED"
-    else
-        echo "⮛ $RX_SPEED ⮙ $TX_SPEED $(date '+❬ %H:%M ❬ %Y-%m-%d')"
-    fi
-done
+echo "  $RX_SPEED  $TX_SPEED "

--- a/src/netspeed.sh
+++ b/src/netspeed.sh
@@ -4,8 +4,14 @@
 # email : freakybytes@duck.com
 #<------------------------------------------------------------------------------------------>
 
-# Choose wlan0 as main interface
-INTERFACE="wlan0"
+# Check the global value
+SHOW_NETSPEED=$(tmux show-option -gv @tokyo-night-tmux_show_netspeed)
+if [ "$SHOW_NETSPEED" != "1" ]; then
+    exit 0
+fi
+
+# Get network interface
+INTERFACE=$(tmux show-option -gv @tokyo-night-tmux_netspeed_iface 2>/dev/null)
 
 # Get network transmit data from /proc/net/dev
 get_bytes() {

--- a/src/netspeed.sh
+++ b/src/netspeed.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#<------------------------------Netspeed widget for TMUX------------------------------------>
+# author : @tribhuwan-kumar
+# email : freakybytes@duck.com
+#<------------------------------------------------------------------------------------------>
+
+# Choose wlan0 as main interface
+INTERFACE="wlan0"
+
+# Get network transmit data from /proc/net/dev
+get_bytes() {
+    awk -v interface="$1" '$1 == interface ":" {print $2, $10}' /proc/net/dev
+}
+
+# Convert into readable format
+readable_format() {
+    local bytes=$1
+
+    # Convert bytes to KBps, 'bc' is dependency, 'pacman -S bc'
+    local kbps=$(echo "scale=1; $bytes / 1024" | bc)
+    if (( $(echo "$kbps < 1" | bc -l) )); then
+        echo "0.0B"
+    elif (( $(echo "$kbps >= 1024" | bc -l) )); then
+        # Convert KBps to MBps
+        local mbps=$(echo "scale=1; $kbps / 1024" | bc)
+        echo "${mbps}MB/s"
+    else
+        echo "${kbps}KB/s"
+    fi
+}
+
+# Echo with truncate condition
+while true; do
+    read RX1 TX1 < <(get_bytes "$INTERFACE")
+    sleep 1
+    read RX2 TX2 < <(get_bytes "$INTERFACE")
+
+    RX_DIFF=$((RX2 - RX1))
+    TX_DIFF=$((TX2 - TX1))
+
+    TIME_DIFF=1
+
+    RX_SPEED=$(readable_format "$((RX_DIFF / TIME_DIFF))")
+    TX_SPEED=$(readable_format "$((TX_DIFF / TIME_DIFF))")
+
+    width=$(tmux display -p '#{window_width}')
+    if [ "$width" -lt 115 ]; then
+        echo "⮛ $RX_SPEED ⮙ $TX_SPEED"
+    else
+        echo "⮛ $RX_SPEED ⮙ $TX_SPEED $(date '+❬ %H:%M ❬ %Y-%m-%d')"
+    fi
+done

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -39,6 +39,7 @@ window_id_style="${window_id_style:-$default_window_id_style}"
 pane_id_style="${pane_id_style:-$default_pane_id_style}"
 zoom_id_style="${zoom_id_style:-$default_zoom_id_style}"
 
+netspeed="#($SCRIPTS_PATH/netspeed.sh)"
 cmus_status="#($SCRIPTS_PATH/music-tmux-statusbar.sh)"
 git_status="#($SCRIPTS_PATH/git-status.sh #{pane_current_path})"
 wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
@@ -57,5 +58,5 @@ tmux set -g window-status-current-format "#[fg=#44dfaf,bg=#1F2335]   #[fg=#a9
 tmux set -g window-status-format "#[fg=#c0caf5,bg=default,none,dim]   $window_number #W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=yellow,blink] #{?window_last_flag,󰁯 ,} "
 
 #+--- Bars RIGHT ---+
-tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B]  %Y-%m-%d #[]❬ %H:%M $git_status$wb_git_status"
+tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B] $netspeed $git_status$wb_git_status"
 tmux set -g window-status-separator ""

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -58,5 +58,5 @@ tmux set -g window-status-current-format "#[fg=#44dfaf,bg=#1F2335]   #[fg=#a9
 tmux set -g window-status-format "#[fg=#c0caf5,bg=default,none,dim]   $window_number #W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=yellow,blink] #{?window_last_flag,󰁯 ,} "
 
 #+--- Bars RIGHT ---+
-tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B] $netspeed $git_status$wb_git_status"
+tmux set -g status-right "$cmus_status#[fg=#a9b1d6,bg=#24283B]$netspeed$git_status$wb_git_status#[fg=#a9b1d6,bg=#24283B]  %Y-%m-%d #[]❬ %H:%M "
 tmux set -g window-status-separator ""


### PR DESCRIPTION
## Major changes
added a shell script in `src` directory for getting the real time network speed, hide the music duration from right side status bar & added `GNU bc` as requirement in `README.md`.
Tested in Arch linux, everything is working fine!

# Preview
![image](https://iili.io/JXGqy4s.png)



Maybe you should check in macOS

Enhanced #45 
