### PR TITLE
git-status performance and safety fixes

### DIFF
--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -6,8 +6,8 @@ if [ "$SHOW_NETSPEED" == "0" ]; then
 fi
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $CURRENT_DIR/themes.sh
-source $CURRENT_DIR/../lib/coreutils-compat.sh
+source "$CURRENT_DIR/../lib/coreutils-compat.sh"
+source "$CURRENT_DIR/themes.sh"
 
 cd "$1" || exit 1
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -18,7 +18,7 @@ BRANCH_SIZE=${#BRANCH}
 SYNC_MODE=0
 NEED_PUSH=0
 
-if test "$BRANCH_SIZE" -gt "25"; then
+if [[ $BRANCH_SIZE -gt 25 ]]; then
   BRANCH=$(echo "$BRANCH" | cut -c1-25)"…"
 fi
 
@@ -27,7 +27,7 @@ STATUS_INSERTIONS=""
 STATUS_DELETIONS=""
 STATUS_UNTRACKED=""
 
-if test "$STATUS" != "0"; then
+if [[ $STATUS -ne 0 ]]; then
   DIFF_COUNTS=($(git diff --numstat 2>/dev/null | awk 'NF==3 {changed+=1; ins+=$1; del+=$2} END {printf("%d %d %d", changed, ins, del)}'))
   CHANGED_COUNT=${DIFF_COUNTS[0]}
   INSERTIONS_COUNT=${DIFF_COUNTS[1]}
@@ -96,8 +96,8 @@ else
   REMOTE_STATUS="$RESET#[fg=#73daca,bg=#15161e,bold]▒ "
 fi
 
-if test "$BRANCH" != ""; then
-  if test "$STATUS" = "0"; then
+if [[ -n $BRANCH ]]; then
+  if [[ $STATUS -eq 0 ]]; then
     echo "$REMOTE_STATUS $RESET$BRANCH $RESET$STATUS_UNTRACKED"
   else
     echo "$REMOTE_STATUS $RESET$BRANCH $RESET$STATUS_CHANGED$RESET$STATUS_INSERTIONS$RESET$STATUS_DELETIONS$RESET$STATUS_UNTRACKED"

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -13,13 +13,12 @@ cd "$1" || exit 1
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")
-BRANCH_SIZE=${#BRANCH}
 
 SYNC_MODE=0
 NEED_PUSH=0
 
-if [[ $BRANCH_SIZE -gt 25 ]]; then
-  BRANCH=$(echo "$BRANCH" | cut -c1-25)"…"
+if [[ ${#BRANCH} -gt 25 ]]; then
+  BRANCH="${BRANCH:0:25}…"
 fi
 
 STATUS_CHANGED=""

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -38,28 +38,28 @@ fi
 
 STATUS_UNTRACKED="$(git ls-files --other --directory --exclude-standard | wc -l | bc)"
 
-if [[ $CHANGED_COUNT > 0 ]]; then
+if [[ $CHANGED_COUNT -gt 0 ]]; then
   STATUS_CHANGED="#[fg=${THEME[yellow]},bg=${THEME[background]},bold] ${CHANGED_COUNT} "
 fi
 
-if [[ $INSERTIONS_COUNT > 0 ]]; then
+if [[ $INSERTIONS_COUNT -gt 0 ]]; then
   STATUS_INSERTIONS="#[fg=${THEME[green]},bg=${THEME[background]},bold] ${INSERTIONS_COUNT} "
 fi
 
-if [[ $DELETIONS_COUNT > 0 ]]; then
+if [[ $DELETIONS_COUNT -gt 0 ]]; then
   STATUS_DELETIONS="#[fg=${THEME[red]},bg=${THEME[background]},bold] ${DELETIONS_COUNT} "
 fi
 
-if [[ $STATUS_UNTRACKED > 0 ]]; then
+if [[ $STATUS_UNTRACKED -gt 0 ]]; then
   STATUS_UNTRACKED="#[fg=#565f89,bg=#15161e,bold] ${STATUS_UNTRACKED} "
 else
   STATUS_UNTRACKED=""
 fi
 
 # Determine repository sync status
-if [[ $SYNC_MODE == 0 ]]; then
+if [[ $SYNC_MODE -eq 0 ]]; then
   NEED_PUSH=$(git log @{push}.. | wc -l | bc)
-  if [[ $NEED_PUSH > 0 ]]; then
+  if [[ $NEED_PUSH -gt 0 ]]; then
     SYNC_MODE=2
   else
     LAST_FETCH=$(stat -c %Y .git/FETCH_HEAD | bc)
@@ -71,13 +71,13 @@ if [[ $SYNC_MODE == 0 ]]; then
     fi
 
     REMOTE_DIFF="$(git diff --shortstat $(git rev-parse --abbrev-ref HEAD) origin/$(git rev-parse --abbrev-ref HEAD) 2>/dev/null | wc -l | bc)"
-    if [[ $REMOTE_DIFF > 0 ]]; then
+    if [[ $REMOTE_DIFF -gt 0 ]]; then
       SYNC_MODE=3
     fi
   fi
 fi
 
-if [[ $SYNC_MODE > 0 ]]; then
+if [[ $SYNC_MODE -gt 0 ]]; then
   case "$SYNC_MODE" in
   1)
     REMOTE_STATUS="$RESET#[bg=#15161e,fg=#ff9e64,bold]▒ 󱓎"

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -9,7 +9,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $CURRENT_DIR/themes.sh
 source $CURRENT_DIR/../lib/coreutils-compat.sh
 
-cd "$1"
+cd "$1" || exit 1
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -9,7 +9,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $CURRENT_DIR/themes.sh
 source $CURRENT_DIR/../lib/coreutils-compat.sh
 
-cd $1
+cd "$1"
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")
@@ -20,7 +20,7 @@ NEED_PUSH=0
 NEED_PULL=0
 
 if test "$BRANCH_SIZE" -gt "25"; then
-  BRANCH=$(echo $BRANCH | cut -c1-25)"…"
+  BRANCH=$(echo "$BRANCH" | cut -c1-25)"…"
 fi
 
 STATUS_CHANGED=""
@@ -71,7 +71,7 @@ if [[ $SYNC_MODE -eq 0 ]]; then
       git fetch --atomic origin --negotiation-tip=HEAD
     fi
 
-    REMOTE_DIFF="$(git diff --shortstat $(git rev-parse --abbrev-ref HEAD) origin/$(git rev-parse --abbrev-ref HEAD) 2>/dev/null | wc -l | bc)"
+    REMOTE_DIFF="$(git diff --shortstat "$(git rev-parse --abbrev-ref HEAD)" "origin/$(git rev-parse --abbrev-ref HEAD)" 2>/dev/null | wc -l | bc)"
     if [[ $REMOTE_DIFF -gt 0 ]]; then
       SYNC_MODE=3
     fi

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -12,7 +12,7 @@ source $CURRENT_DIR/../lib/coreutils-compat.sh
 cd $1
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-STATUS=$(git status --porcelain 2>/dev/null | egrep "^(M| M)" | wc -l)
+STATUS=$(git status --porcelain 2>/dev/null | grep -E "^(M| M)" | wc -l)
 BRANCH_SIZE=${#BRANCH}
 
 SYNC_MODE=0

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -17,7 +17,6 @@ BRANCH_SIZE=${#BRANCH}
 
 SYNC_MODE=0
 NEED_PUSH=0
-NEED_PULL=0
 
 if test "$BRANCH_SIZE" -gt "25"; then
   BRANCH=$(echo "$BRANCH" | cut -c1-25)"…"

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -12,7 +12,7 @@ source $CURRENT_DIR/../lib/coreutils-compat.sh
 cd $1
 RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounderscore,nodim]"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-STATUS=$(git status --porcelain 2>/dev/null | grep -E "^(M| M)" | wc -l)
+STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")
 BRANCH_SIZE=${#BRANCH}
 
 SYNC_MODE=0
@@ -29,9 +29,10 @@ STATUS_DELETIONS=""
 STATUS_UNTRACKED=""
 
 if test "$STATUS" != "0"; then
-  CHANGED_COUNT=$(git diff --shortstat 2>/dev/null | tr "," "\n" | grep "chang" | cut -d" " -f2 | bc)
-  INSERTIONS_COUNT="$(git diff --shortstat 2>/dev/null | tr "," "\n" | grep "ins" | cut -d" " -f2 | bc)"
-  DELETIONS_COUNT="$(git diff --shortstat 2>/dev/null | tr "," "\n" | grep "del" | cut -d" " -f2 | bc)"
+  DIFF_COUNTS=($(git diff --numstat 2>/dev/null | awk 'NF==3 {changed+=1; ins+=$1; del+=$2} END {printf("%d %d %d", changed, ins, del)}'))
+  CHANGED_COUNT=${DIFF_COUNTS[0]}
+  INSERTIONS_COUNT=${DIFF_COUNTS[1]}
+  DELETIONS_COUNT=${DIFF_COUNTS[2]}
 
   SYNC_MODE=1
 fi

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -78,16 +78,16 @@ fi
 # Set the status indicator based on the sync mode
 case "$SYNC_MODE" in
 1)
-  REMOTE_STATUS="$RESET#[bg=#15161e,fg=#ff9e64,bold]▒ 󱓎"
+  REMOTE_STATUS="$RESET#[bg=#15161e,fg=${THEME[bred]},bold]▒ 󱓎"
   ;;
 2)
-  REMOTE_STATUS="$RESET#[bg=#15161e,fg=#f7768e,bold]▒ 󰛃"
+  REMOTE_STATUS="$RESET#[bg=#15161e,fg=${THEME[red]},bold]▒ 󰛃"
   ;;
 3)
-  REMOTE_STATUS="$RESET#[bg=#15161e,fg=#bb9af7,bold]▒ 󰛀"
+  REMOTE_STATUS="$RESET#[bg=#15161e,fg=${THEME[magenta]},bold]▒ 󰛀"
   ;;
 *)
-  REMOTE_STATUS="$RESET#[fg=#73daca,bg=#15161e,bold]▒ "
+  REMOTE_STATUS="$RESET#[bg=#15161e,fg=${THEME[green]},bold]▒ "
   ;;
 esac
 

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -29,11 +29,9 @@ if [[ -n $BRANCH ]]; then
 fi
 
 if [[ $PROVIDER == "github.com" ]]; then
-
   if ! command -v gh &>/dev/null; then
     exit 1
   fi
-
   PROVIDER_ICON="$RESET#[fg=${THEME[foreground]}] "
   PR_COUNT=$(gh pr list --json number --jq 'length' | bc)
   REVIEW_COUNT=$(gh pr status --json reviewRequests --jq '.needsReview | length' | bc)
@@ -41,11 +39,16 @@ if [[ $PROVIDER == "github.com" ]]; then
   ISSUE_COUNT=$(echo $RES | jq 'length' | bc)
   BUG_COUNT=$(echo $RES | jq 'map(select(.labels[].name == "bug")) | length' | bc)
   ISSUE_COUNT=$((ISSUE_COUNT - BUG_COUNT))
-else
+elif [[ $PROVIDER == "gitlab.com" ]]; then
+  if ! command -v glab &>/dev/null; then
+    exit 1
+  fi
   PROVIDER_ICON="$RESET#[fg=#fc6d26] "
   PR_COUNT=$(glab mr list | grep -cE "^\!")
   REVIEW_COUNT=$(glab mr list --reviewer=@me | grep -cE "^\!")
   ISSUE_COUNT=$(glab issue list | grep -cE "^\#")
+else
+  exit 0
 fi
 
 if [[ $PR_COUNT -gt 0 ]]; then

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -36,8 +36,8 @@ if [[ $PROVIDER == "github.com" ]]; then
   PR_COUNT=$(gh pr list --json number --jq 'length' | bc)
   REVIEW_COUNT=$(gh pr status --json reviewRequests --jq '.needsReview | length' | bc)
   RES=$(gh issue list --json "assignees,labels" --assignee @me)
-  ISSUE_COUNT=$(echo $RES | jq 'length' | bc)
-  BUG_COUNT=$(echo $RES | jq 'map(select(.labels[].name == "bug")) | length' | bc)
+  ISSUE_COUNT=$(echo "$RES" | jq 'length' | bc)
+  BUG_COUNT=$(echo "$RES" | jq 'map(select(.labels[].name == "bug")) | length' | bc)
   ISSUE_COUNT=$((ISSUE_COUNT - BUG_COUNT))
 elif [[ $PROVIDER == "gitlab.com" ]]; then
   if ! command -v glab &>/dev/null; then

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -14,7 +14,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 cd $1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
-STATUS=$(git status --porcelain 2>/dev/null | egrep "^(M| M)" | wc -l)
+STATUS=$(git status --porcelain 2>/dev/null | grep -E "^(M| M)" | wc -l)
 
 PROVIDER_ICON=""
 

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -56,23 +56,23 @@ else
   fi
 fi
 
-if [[ $PR_COUNT > 0 ]]; then
+if [[ $PR_COUNT -gt 0 ]]; then
   PR_STATUS="#[fg=${THEME[ghgreen]},bg=${THEME[background]},bold] ${RESET}${PR_COUNT} "
 fi
 
-if [[ $REVIEW_COUNT > 0 ]]; then
+if [[ $REVIEW_COUNT -gt 0 ]]; then
   REVIEW_STATUS="#[fg=${THEME[ghyellow]},bg=${THEME[background]},bold] ${RESET}${REVIEW_COUNT} "
 fi
 
-if [[ $ISSUE_COUNT > 0 ]]; then
+if [[ $ISSUE_COUNT -gt 0 ]]; then
   ISSUE_STATUS="#[fg=${THEME[ghgreen]},bg=${THEME[background]},bold] ${RESET}${ISSUE_COUNT} "
 fi
 
-if [[ $BUG_COUNT > 0 ]]; then
+if [[ $BUG_COUNT -gt 0 ]]; then
   BUG_STATUS="#[fg=${THEME[ghred]},bg=${THEME[background]},bold] ${RESET}${BUG_COUNT} "
 fi
 
-if [[ $PR_COUNT > 0 || $REVIEW_COUNT > 0 || $ISSUE_COUNT > 0 ]]; then
+if [[ $PR_COUNT -gt 0 || $REVIEW_COUNT -gt 0 || $ISSUE_COUNT -gt 0 ]]; then
   WB_STATUS="#[fg=${THEME[black]},bg=${THEME[background]},bold] $RESET$PROVIDER_ICON $RESET$PR_STATUS$REVIEW_STATUS$ISSUE_STATUS$BUG_STATUS"
 fi
 
@@ -81,6 +81,6 @@ echo "$WB_STATUS"
 # Wait extra time if status-interval is less than 30 seconds to
 # avoid to overload GitHub API
 INTERVAL="$(tmux show -g | grep status-interval | cut -d" " -f2 | bc)"
-if [[ $INTERVAL < 20 ]]; then
+if [[ $INTERVAL -lt 20 ]]; then
   sleep 20
 fi

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -5,13 +5,10 @@ if [ "$SHOW_WIDGET" == "0" ]; then
 fi
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source $CURRENT_DIR/themes.sh
+source "$CURRENT_DIR../lib/coreutils-compat.sh"
+source "$CURRENT_DIR/themes.sh"
 
-# Imports
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
-. "${ROOT_DIR}/lib/coreutils-compat.sh"
-
-cd $1
+cd "$1"
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
 STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -14,7 +14,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 cd $1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
-STATUS=$(git status --porcelain 2>/dev/null | grep -E "^(M| M)" | wc -l)
+STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")
 
 PROVIDER_ICON=""
 
@@ -48,9 +48,9 @@ if [[ $PROVIDER == "github.com" ]]; then
 else
   PROVIDER_ICON="$RESET#[fg=#fc6d26] "
   if test "$BRANCH" != ""; then
-    PR_COUNT=$(glab mr list | grep -E "^\!" | wc -l | bc)
-    REVIEW_COUNT=$(glab mr list --reviewer=@me | grep -E "^\!" | wc -l | bc)
-    ISSUE_COUNT=$(glab issue list | grep -E "^\#" | wc -l | bc)
+    PR_COUNT=$(glab mr list | grep -cE "^\!")
+    REVIEW_COUNT=$(glab mr list --reviewer=@me | grep -cE "^\!")
+    ISSUE_COUNT=$(glab issue list | grep -cE "^\#")
   else
     exit 0
   fi

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -8,7 +8,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR../lib/coreutils-compat.sh"
 source "$CURRENT_DIR/themes.sh"
 
-cd "$1"
+cd "$1" || exit 1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
 STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -11,7 +11,6 @@ source "$CURRENT_DIR/themes.sh"
 cd "$1" || exit 1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
-STATUS=$(git status --porcelain 2>/dev/null | grep -cE "^(M| M)")
 
 PROVIDER_ICON=""
 

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -31,7 +31,7 @@ if [[ $PROVIDER == "github.com" ]]; then
   fi
 
   PROVIDER_ICON="$RESET#[fg=${THEME[foreground]}] "
-  if test "$BRANCH" != ""; then
+  if [[ -n $BRANCH ]]; then
     PR_COUNT=$(gh pr list --json number --jq 'length' | bc)
     REVIEW_COUNT=$(gh pr status --json reviewRequests --jq '.needsReview | length' | bc)
     RES=$(gh issue list --json "assignees,labels" --assignee @me)
@@ -43,7 +43,7 @@ if [[ $PROVIDER == "github.com" ]]; then
   fi
 else
   PROVIDER_ICON="$RESET#[fg=#fc6d26] "
-  if test "$BRANCH" != ""; then
+  if [[ -n $BRANCH ]]; then
     PR_COUNT=$(glab mr list | grep -cE "^\!")
     REVIEW_COUNT=$(glab mr list --reviewer=@me | grep -cE "^\!")
     ISSUE_COUNT=$(glab issue list | grep -cE "^\#")


### PR DESCRIPTION
The main reason for this PR is that due to the sheer number of calls to git during these calculations, actual git commands were failing due to the locks. Multiple commands have been replaced with single, lock-safe checks and other comparisons made to reduce calls to upstream fixed.

## Minor changes

- [X] Reduce call count for git-status calculations

## Bug & security fixes

- [X] Numerical comparisons in git-status
- [X] Improved safety checks for git-status
- [X] Only apply Gitlab status checks to Gitlab repos