### PR TITLE
Implement BATS workflow

### DIFF
--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -77,3 +77,14 @@ jobs:
         with:
           name: report-macOS-${{ matrix.libs }}
           path: report.xml
+  junit-publish:
+    needs: [bats-alpine, bats-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: "**/report.xml"

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -11,6 +11,7 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         bash: ["bash:4.2", "bash:4.4", "bash:5.0", "bash:5.2"]
     container:
@@ -39,6 +40,7 @@ jobs:
   bats-macos:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         libs: ["gnu", "builtin"]
     steps:

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -3,7 +3,7 @@ name: BATS Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, next]
 
   workflow_dispatch:
 

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tokyo-night-tmux tests
+        shell: bash -e {0}
         run: bats --verbose-run test/
   bats-macos:
     runs-on: macos-latest

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -1,0 +1,51 @@
+name: BATS Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+  workflow_dispatch:
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bash: ["bash:4.2", "bash:4.4", "bash:5.0", "bash:5.2"]
+    container:
+      image: ${{ matrix.bash }}
+    steps:
+      - name: Install packages
+        run: apk add bc coreutils curl git sudo tar
+
+      # Allow tar to cache system paths
+      - name: root suid tar
+        run: sudo chown root:wheel /bin/tar && sudo chmod u+s /bin/tar
+
+      - name: Setup Bats and bats libs
+        uses: stealthii/bats-action@main
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tokyo-night-tmux tests
+        run: bats --verbose-run test/
+  bats-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Install Homebrew packages
+        run: |
+          brew install bash bc coreutils curl git
+
+      - name: Setup Bats and bats libs
+        run: |
+          brew install bats-core
+          brew tap stealthii/bats-core
+          brew install bats-support bats-assert bats-file bats-detik bats-mock
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run tokyo-night-tmux tests
+        run: bats --verbose-run test/

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -17,7 +17,11 @@ jobs:
       image: ${{ matrix.bash }}
     steps:
       - name: Install packages
-        run: apk add bc coreutils curl git sudo tar
+        run: |
+          # Pipeline requirements
+          apk add curl git sudo tar
+          # Theme dependencies
+          apk add bc coreutils gawk jq playerctl sed
 
       # Allow tar to cache system paths
       - name: root suid tar
@@ -36,7 +40,8 @@ jobs:
     steps:
       - name: Install Homebrew packages
         run: |
-          brew install bash bc coreutils curl git
+          # Theme dependencies
+          brew install bash bc coreutils jq nowplaying-cli
 
       - name: Setup Bats and bats libs
         run: |

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -8,14 +8,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  bats:
+  bats-alpine:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        bash: ["bash:4.2", "bash:4.4", "bash:5.0", "bash:5.2"]
+        bash: ["4.2", "4.4", "5.0", "5.2"]
     container:
-      image: ${{ matrix.bash }}
+      image: bash:${{ matrix.bash }}
     steps:
       - name: Install packages
         run: |
@@ -36,7 +36,14 @@ jobs:
 
       - name: Run tokyo-night-tmux tests
         shell: bash -e {0}
-        run: bats --verbose-run test/
+        run: bats --verbose-run --report-formatter junit test/
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: report-alpine-${{ matrix.bash }}
+          path: report.xml
   bats-macos:
     runs-on: macos-latest
     strategy:
@@ -62,4 +69,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run tokyo-night-tmux tests
-        run: bats --verbose-run test/
+        run: bats --verbose-run --report-formatter junit test/
+
+      - name: Upload Test Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: report-macOS-${{ matrix.libs }}
+          path: report.xml

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -37,11 +37,17 @@ jobs:
         run: bats --verbose-run test/
   bats-macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        libs: ["gnu", "builtin"]
     steps:
       - name: Install Homebrew packages
         run: |
           # Theme dependencies
-          brew install bash bc coreutils jq nowplaying-cli
+          brew install bash jq nowplaying-cli
+          if [[ "${{ matrix.libs }}" == "gnu" ]]; then
+            brew install bc coreutils gawk gsed
+          fi
 
       - name: Setup Bats and bats libs
         run: |

--- a/.github/workflows/bats-multi-bash.yml
+++ b/.github/workflows/bats-multi-bash.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install packages
         run: |
           # Pipeline requirements
-          apk add curl git sudo tar
+          apk add curl git ncurses parallel sudo tar
           # Theme dependencies
           apk add bc coreutils gawk jq playerctl sed
 

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,10 +1,9 @@
-name: BATS Tests
+name: bats
 
 on:
   pull_request:
   push:
     branches: [master, next]
-
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, next]
 
 jobs:
   pre-commit:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,26 @@
+name: report
+on:
+  workflow_run:
+    workflows: [bats]
+    types: [completed]
+
+permissions:
+  checks: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Test Report
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: report-.*
+          name_is_regexp: true
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        with:
+          commit: ${{github.event.workflow_run.head_sha}}
+          report_paths: "**/report.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JUnit reports
+**/report.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,18 @@
 repos:
-  - repo: https://github.com/pecigonzalo/pre-commit-shfmt
-    rev: v2.1.0
+  - repo: local
     hooks:
       - id: shell-fmt-go
+        name: shfmt
+        description: Rewrites all shell scripts to a canonical format.
+        language: golang
+        additional_dependencies:
+          - mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
+        entry: shfmt
+        types:
+          - file
+          - shell
+        exclude_types:
+          - zsh
         args:
           - -w
           - -s

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This theme requires the following:
 
 - [Noto Sans] and one of any patched [Nerd Fonts]
 - GNU [coreutils] and [bc]
-- Bash 4.0 or newer
+- [jq]
+- Bash 4.2 or newer
+- [playerctl] (Linux) or [nowplaying-cli] (macOS) for music statusbar
 
 ### macOS
 
@@ -28,19 +30,30 @@ For macOS, you can install all dependencies via [Homebrew]:
 ```bash
 brew tap homebrew/cask-fonts
 brew install --cask font-monaspace-nerd-font font-noto-sans
-brew install bash bc coreutils gawk gsed
+brew install bash bc coreutils gawk gsed jq nowplaying-cli
 ```
 
 ### Linux
 
-GNU coreutils are already installed on most Linux distributions. You can
-install `bc` via your package manager. For example, on Arch Linux:
+#### Alpine Linux
 
 ```bash
-pacman -S bc
+apk add bash bc coreutils gawk git jq playerctl sed
 ```
 
-Check documentation for installing [bc] on other operating systems.
+#### Arch Linux
+
+```bash
+pacman -Sy bash bc coreutils git jq playerctl
+```
+
+#### Ubuntu
+
+```bash
+apt-get install bash bc coreutils gawk git jq playerctl
+```
+
+Check documentation for installing on other operating systems.
 
 ## Installation using TPM
 
@@ -148,7 +161,7 @@ so it's independent of terminal theme.
 - Remote branch sync indicator (you will never forget to push or pull again 🤪).
 - Great terminal icons.
 - Prefix highlight incorporated.
-- Now Playing status bar, supporting [cmus]/[nowplaying-cli]
+- Now Playing status bar, supporting [playerctl]/[nowplaying-cli]
 - Windows has custom pane number indicator.
 - Pane zoom mode indicator.
 - Date and time.
@@ -187,11 +200,12 @@ Ensure your editor follows the style guide provided by `.editorconfig`.
 [pre-commit] hooks are also provided to ensure code consistency, and will be
 run against any raised PRs.
 
-[cmus]: https://cmus.github.io/
-[nowplaying-cli]: https://github.com/kirtan-shah/nowplaying-cli
 [pre-commit]: https://pre-commit.com/
 [Noto Sans]: https://fonts.google.com/noto/specimen/Noto+Sans
 [Nerd Fonts]: https://www.nerdfonts.com/
 [coreutils]: https://www.gnu.org/software/coreutils/
 [bc]: https://www.gnu.org/software/bc/
+[jq]: https://jqlang.github.io/jq/
+[playerctl]: https://github.com/altdesktop/playerctl
+[nowplaying-cli]: https://github.com/kirtan-shah/nowplaying-cli
 [Homebrew]: https://brew.sh/

--- a/README.md
+++ b/README.md
@@ -15,22 +15,27 @@ This is a very opinionated project, as I am a Tech Lead, this theme is very deve
 
 ## Requirements
 
-This theme requires the following:
+This theme has the following hard requirements:
 
-- [Noto Sans] and one of any patched [Nerd Fonts]
-- GNU [coreutils] and [bc]
-- [jq]
+- Any patched [Nerd Fonts] (v3 or higher)
 - Bash 4.2 or newer
+
+The following are recommended for full support of all widgets and features:
+
+- [Noto Sans] Symbols 2 (for segmented digit numbers)
+- [bc] (for netspeed and git widgets)
+- [jq], [gh], [glab] (for git widgets)
 - [playerctl] (Linux) or [nowplaying-cli] (macOS) for music statusbar
 
 ### macOS
 
-For macOS, you can install all dependencies via [Homebrew]:
+macOS still ships with bash 3.2 so you must provide a newer version.
+You can easily install all dependencies via [Homebrew]:
 
 ```bash
 brew tap homebrew/cask-fonts
-brew install --cask font-monaspace-nerd-font font-noto-sans
-brew install bash bc coreutils gawk gsed jq nowplaying-cli
+brew install --cask font-monaspace-nerd-font font-noto-sans-symbols-2
+brew install bash bc coreutils gawk gh glab gsed jq nowplaying-cli
 ```
 
 ### Linux

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -24,7 +24,7 @@ REVIEW_STATUS=""
 ISSUE_STATUS=""
 BUG_STATUS=""
 
-if [[ -z "$BRANCH" ]]; then
+if [[ -z $BRANCH ]]; then
   exit 0
 fi
 

--- a/test/stub.bats
+++ b/test/stub.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "stub test" {
+  run echo "stub test"
+  [[ $status -eq 0 ]]
+}


### PR DESCRIPTION
This PR implements the [bats](https://bats-core.readthedocs.io/) test runner as a workflow, providing a stub test to ensure passing until future PRs implement their own.

The purpose of bats for this repo is three-fold functionality testing:
* multiple Bash versions (4.2, 4.4, 5.0, 5.2)
* multiple OS flavors (macOS, Linux)
* Alternate versions of bc, awk, git, date, etc. (where necessary)

**Tests are completely optional**, and realistically should only exist for core components where functionality differs between OS flavors (such as the music widget), and non-portable syntax (use of implementation specific features in `bc`, `awk`, `date`, etc.)

Discussion in comments.

---

## Minor changes

- [X] Update known dependencies for tokyo-night-tmux
- [X] Provide dependency installation examples for macOS, Alpine, Arch, and Ubuntu