### PR TITLE
Add info on how to get battery indication for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ set -g @tokyo-night-tmux_path_format relative # 'relative' or 'full'
 
 ```bash
 set -g @tokyo-night-tmux_show_battery_widget 1
-set -g @tokyo-night-tmux_battery_name "BAT1"  # some linux distro have 'BAT0'
+set -g @tokyo-night-tmux_battery_name "BAT1"  # some linux distro have 'BAT0', MacOS uses 'InternalBattery-0'
 set -g @tokyo-night-tmux_battery_low_threshold 21 # default
 ```
 


### PR DESCRIPTION
Small readme update just to tell people the identifier for battery status on MacOS. Tested on Sonoma 14.5 with a M1 MacBook.

## Major changes

- [X] Closes #...
- [ ] Closes #...
- [ ] Closes #...

## Minor changes

- [X] Resolves #...
- [ ] Resolves #...
- [ ] Resolves #...

## Bug & security fixes

- [X] Fixes #...
- [ ] Fixes #...
- [ ] Fixes #...

## Additional information

None.
