### PR TITLE
docs: Remove homebrew/cask-fonts tap as fonts are now in homebrew-cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ macOS still ships with bash 3.2 so you must provide a newer version.
 You can easily install all dependencies via [Homebrew]:
 
 ```bash
-brew tap homebrew/cask-fonts
 brew install --cask font-monaspace-nerd-font font-noto-sans-symbols-2
 brew install bash bc coreutils gawk gh glab gsed jq nowplaying-cli
 ```


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/173925
