### PR TITLE
feat: add hostname widget

### DIFF
--- a/src/hostname-widget.sh
+++ b/src/hostname-widget.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Imports
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+. "${ROOT_DIR}/lib/coreutils-compat.sh"
+
+# get value from tmux config
+SHOW_HOST=$(tmux show-option -gv @tokyo-night-tmux_show_host 2>/dev/null)
+HOST_FORMAT=$(tmux show-option -gv @tokyo-night-tmux_host_format 2>/dev/null) # user | host | both (default)
+RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
+
+# check if not enabled
+if [ "${SHOW_HOST}" != "1" ]; then
+  exit 0
+fi
+
+if [[ ${HOST_FORMAT} == "user" ]]; then
+  host_string="$(whoami)"
+elif [[ ${HOST_FORMAT} == "host" ]]; then
+  host_string="$(hostname)"
+else
+  host_string="$(whoami)@$(hostname)"
+fi
+
+echo "#[fg=blue,bg=default]󰒋 ${RESET}#[bg=default]${host_string} "

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -51,6 +51,7 @@ zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
 date_and_time="$($SCRIPTS_PATH/datetime-widget.sh)"
 current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
+host="#($SCRIPTS_PATH/hostname-widget.sh)"
 
 #+--- Bars LEFT ---+
 # Session name
@@ -63,5 +64,5 @@ tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[
 tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 , }${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
 
 #+--- Bars RIGHT ---+
-tmux set -g status-right "$battery_status$current_path$cmus_status$netspeed$git_status$wb_git_status$date_and_time"
+tmux set -g status-right "$battery_status$current_path$host$cmus_status$netspeed$git_status$wb_git_status$date_and_time"
 tmux set -g window-status-separator ""


### PR DESCRIPTION
Implement #95.

<img width="490" alt="image" src="https://github.com/user-attachments/assets/513818cf-77c7-4691-958e-ff5caf0cd8a4">

Add options:
```sh
set -g @tokyo-night-tmux_show_host 1
set -g @tokyo-night-tmux_host_format both  # 'user' or 'host' or 'both' (default)
```
