### PR TITLE
feat(theme): Add support for transparent Statusbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ set -g @plugin "janoamaral/tokyo-night-tmux"
 
 ## Configuration
 
+### Themes
+
+Use following option to change theme preference:
+
+```bash
+set -g @tokyo-night-tmux_theme storm    # storm | day | default to 'night'
+set -g @tokyo-night-tmux_transparent 1  # 1 or 0
+```
+
 ### Number styles
 
 Run these commands in your terminal:

--- a/src/battery-widget.sh
+++ b/src/battery-widget.sh
@@ -50,7 +50,6 @@ battery_exists() {
 
 # Exit if no battery is found
 if ! battery_exists; then
-  echo "#[fg=green,bg=default]░ ${NOT_CHARGING_ICON}${RESET}#[bg=default]"
   exit 0
 fi
 

--- a/src/themes.sh
+++ b/src/themes.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SELECTED_THEME="$(tmux show-option -gv @tokyo-night-tmux_theme)"
-TRANSPARENT_THEME="$(tmux show-option -gv @tokyo-night-tmux_transparent)"   # 0 or 1
+TRANSPARENT_THEME="$(tmux show-option -gv @tokyo-night-tmux_transparent)"
 
 case $SELECTED_THEME in
 "storm")

--- a/src/themes.sh
+++ b/src/themes.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 SELECTED_THEME="$(tmux show-option -gv @tokyo-night-tmux_theme)"
+TRANSPARENT_THEME="$(tmux show-option -gv @tokyo-night-tmux_transparent)"   # 0 or 1
 
 case $SELECTED_THEME in
 "storm")
@@ -76,6 +77,11 @@ case $SELECTED_THEME in
   )
   ;;
 esac
+
+# Override background with "default" if transparent theme is enabled
+if [ "${TRANSPARENT_THEME}" == 1 ]; then
+  THEME["background"]="default"
+fi
 
 THEME['ghgreen']="#3fb950"
 THEME['ghmagenta']="#A371F7"


### PR DESCRIPTION

- Introduced `@tokyo-night-tmux_transparent` option to enable transparent background in tmux.
- Modified theme configurations to use terminal's default background when transparency is enabled.
- Ensured background color defaults to `default` when `@tokyo-night-tmux_transparent` is set to 1.
