### PR TITLE
docs: add `hide` number style to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ changing values.
 
 ## Styles
 
+- `hide`: hide number
 - `none`: no style, default font
 - `digital`: 7 segment number (🯰...🯹) (needs [Unicode support](https://github.com/janoamaral/tokyo-night-tmux/issues/36#issuecomment-1907072080))
 - `roman`: roman numbers (󱂈...󱂐) (needs nerdfont)


### PR DESCRIPTION

## Minor changes

- [ ] Adds documentation for the new style introduced in https://github.com/janoamaral/tokyo-night-tmux/pull/89
