### PR TITLE
feat: added minimal mode

### DIFF
--- a/src/datetime-widget.sh
+++ b/src/datetime-widget.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
+  exit 0
+fi
 
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
@@ -6,6 +13,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 
 # Grab global variable for showing datetime widget, only hide if explicitly disabled
 SHOW_DATETIME=$(tmux show-option -gv @tokyo-night-tmux_show_datetime 2>/dev/null)
+"$MINIMAL_SESSION_NAME $TMUX_SESSION_NAME"
+c
 if [[ $SHOW_DATETIME == "0" ]]; then
   exit 0
 fi
@@ -22,30 +31,30 @@ time_string=""
 
 if [[ $date_format == "YMD" ]]; then
   # Year Month Day date format
-  date_string=" %Y-%m-%d"
+  date_string="%Y-%m-%d"
 elif [[ $date_format == "MDY" ]]; then
   # Month Day Year date format
-  date_string=" %m-%d-%Y"
+  date_string="%m-%d-%Y"
 elif [[ $date_format == "DMY" ]]; then
   # Day Month Year date format
-  date_string=" %d-%m-%Y"
+  date_string="%d-%m-%Y"
 elif [[ $date_format == "hide" ]]; then
   # Day Month Year date format
   date_string=""
 else
   # Default to YMD date format if not specified
-  date_string=" %Y-%m-%d"
+  date_string="%Y-%m-%d"
 fi
 
 if [[ $time_format == "12H" ]]; then
   # 12-hour format with AM/PM
-  time_string="%I:%M %p "
+  time_string="%I:%M %p"
 elif [[ $time_format == "hide" ]]; then
   # 24-hour format
   time_string=""
 else
   # Default to 24-hour format if not specified
-  time_string="%H:%M "
+  time_string="%H:%M"
 fi
 
 separator=""
@@ -53,4 +62,7 @@ if [[ $date_string && $time_string ]]; then
   separator="❬ "
 fi
 
-echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}]$date_string $separator$time_string"
+date_string="$(date +$date_string)"
+time_string="$(date +$time_string)"
+
+echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}] $date_string $separator$time_string "

--- a/src/datetime-widget.sh
+++ b/src/datetime-widget.sh
@@ -62,7 +62,7 @@ if [[ $date_string && $time_string ]]; then
   separator="❬ "
 fi
 
-date_string="$(date +$date_string)"
-time_string="$(date +$time_string)"
+date_string="$(date +"$date_string")"
+time_string="$(date +"$time_string")"
 
 echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}] $date_string $separator$time_string "

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
 
 SHOW_NETSPEED=$(tmux show-option -gv @tokyo-night-tmux_show_git)
 if [ "$SHOW_NETSPEED" == "0" ]; then

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
+
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
@@ -28,12 +36,12 @@ fi
 
 # playerctl
 if command -v playerctl >/dev/null; then
-  PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}}" | grep -m1 "Playing")
+  PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}};{{playerName}}" | grep -m1 "Playing")
   STATUS="playing"
 
   # There is no playing media, check for paused media
   if [ -z "$PLAYER_STATUS" ]; then
-    PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}}" | grep -m1 "Paused")
+    PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}};{{playerName}}" | grep -m1 "Paused")
     STATUS="paused"
   fi
 

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
+
 SHOW_WIDGET=$(tmux show-option -gv @tokyo-night-tmux_show_wbg)
 if [ "$SHOW_WIDGET" == "0" ]; then
   exit 0

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -3,7 +3,7 @@
 MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
 TMUX_SESSION_NAME=$(tmux display-message -p '#S')
 
-if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
   exit 0
 fi
 

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -27,6 +27,7 @@ tmux set -g pane-active-border-style "fg=${THEME[blue]}"
 tmux set -g pane-border-status off
 
 tmux set -g status-style bg="${THEME[background]}"
+tmux set -g popup-border-style "fg=${THEME[blue]}"
 
 TMUX_VARS="$(tmux show -g)"
 
@@ -60,7 +61,7 @@ wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I $window_id_style)"
 custom_pane="#($SCRIPTS_PATH/custom-number.sh #P $pane_id_style)"
 zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
-date_and_time="$($SCRIPTS_PATH/datetime-widget.sh)"
+date_and_time="#($SCRIPTS_PATH/datetime-widget.sh)"
 current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
 hostname="#($SCRIPTS_PATH/hostname-widget.sh)"


### PR DESCRIPTION
This pull request introduces several updates to improve functionality and consistency across multiple scripts and configuration files in the project. The most significant changes include adding session-specific checks to ensure widgets and status bars are only displayed in non-minimal sessions, enhancing the `datetime-widget.sh` and `music-tmux-statusbar.sh` scripts, and updating the `tokyo-night.tmux` configuration for better visual customization.

### Session-Specific Checks:
* Added logic in `src/datetime-widget.sh`, `src/git-status.sh`, `src/music-tmux-statusbar.sh`, and `src/wb-git-status.sh` to verify if the current session is the "minimal session." If true, the scripts exit early to avoid unnecessary processing. [[1]](diffhunk://#diff-5ae9500f90304857feed35cb345d17e981c633247b106b9c226c5bf77c1d7852R2-R17) [[2]](diffhunk://#diff-13c9e23e33fa7ab1fc1def8e003943bcdcd8904a265ecc2924bb57c4db250138R2-R8) [[3]](diffhunk://#diff-26f1237bbff23b80065dcfa314b2a7926dfbda915894124a66e4e24c347978bdR3-R10) [[4]](diffhunk://#diff-c0218a72d043e352a2fcb7e91e179702ec4a5f5412a72c2d705685cc9365bbb6R2-R9)

### Widget and Status Enhancements:
* Modified `datetime-widget.sh` to format and display both date and time strings using the `date` command.
* Enhanced `music-tmux-statusbar.sh` to include the `playerName` field in the `playerctl` metadata output, providing more detailed information about the active media player.

### Configuration Updates:
* Added a new `popup-border-style` setting in `tokyo-night.tmux` to customize the popup border color using the theme's blue color.
* Corrected the `date_and_time` widget in `tokyo-night.tmux` to use the proper command substitution syntax for consistency.