### PR TITLE
v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ set -g @tokyo-night-tmux_battery_low_threshold 21 # default
 Set variable value `0` to disable the widget. Remember to restart `tmux` after
 changing values.
 
+#### Web-based Git Widget
+
+This widget shows GitHub/GitLab statistics including PR counts and issues assigned to you. It requires `gh` (GitHub CLI) or `glab` (GitLab CLI) to be installed and authenticated.
+
+```bash
+set -g @tokyo-night-tmux_show_wbg 1
+```
+
+The widget works with both SSH and HTTPS git remote URLs:
+- SSH: `git@github.com:user/repo.git`
+- HTTPS: `https://github.com/user/repo.git`
+
+Set variable value `0` to disable the widget. Remember to restart `tmux` after changing values.
+
 #### Hostname Widget
 
 ```bash

--- a/src/battery-widget.sh
+++ b/src/battery-widget.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
+# Check if the battery widget is enabled
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_battery_widget 2>/dev/null)
+[[ ${ENABLED} -ne 1 ]] && exit 0
+
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
-
-# Check if the battery widget is enabled
-SHOW_BATTERY_WIDGET=$(tmux show-option -gv @tokyo-night-tmux_show_battery_widget 2>/dev/null)
-if [ "${SHOW_BATTERY_WIDGET}" != "1" ]; then
-  exit 0
-fi
 
 # Get values from tmux config or set defaults
 BATTERY_NAME=$(tmux show-option -gv @tokyo-night-tmux_battery_name 2>/dev/null)

--- a/src/datetime-widget.sh
+++ b/src/datetime-widget.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
+  exit 0
+fi
 
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
@@ -6,6 +13,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 
 # Grab global variable for showing datetime widget, only hide if explicitly disabled
 SHOW_DATETIME=$(tmux show-option -gv @tokyo-night-tmux_show_datetime 2>/dev/null)
+"$MINIMAL_SESSION_NAME $TMUX_SESSION_NAME"
+c
 if [[ $SHOW_DATETIME == "0" ]]; then
   exit 0
 fi
@@ -22,30 +31,30 @@ time_string=""
 
 if [[ $date_format == "YMD" ]]; then
   # Year Month Day date format
-  date_string=" %Y-%m-%d"
+  date_string="%Y-%m-%d"
 elif [[ $date_format == "MDY" ]]; then
   # Month Day Year date format
-  date_string=" %m-%d-%Y"
+  date_string="%m-%d-%Y"
 elif [[ $date_format == "DMY" ]]; then
   # Day Month Year date format
-  date_string=" %d-%m-%Y"
+  date_string="%d-%m-%Y"
 elif [[ $date_format == "hide" ]]; then
   # Day Month Year date format
   date_string=""
 else
   # Default to YMD date format if not specified
-  date_string=" %Y-%m-%d"
+  date_string="%Y-%m-%d"
 fi
 
 if [[ $time_format == "12H" ]]; then
   # 12-hour format with AM/PM
-  time_string="%I:%M %p "
+  time_string="%I:%M %p"
 elif [[ $time_format == "hide" ]]; then
   # 24-hour format
   time_string=""
 else
   # Default to 24-hour format if not specified
-  time_string="%H:%M "
+  time_string="%H:%M"
 fi
 
 separator=""
@@ -53,4 +62,7 @@ if [[ $date_string && $time_string ]]; then
   separator="❬ "
 fi
 
-echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}]$date_string $separator$time_string"
+date_string="$(date +$date_string)"
+time_string="$(date +$time_string)"
+
+echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}] $date_string $separator$time_string "

--- a/src/datetime-widget.sh
+++ b/src/datetime-widget.sh
@@ -1,23 +1,12 @@
 #!/usr/bin/env bash
-# Verify if the current session is the minimal session
-MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
-TMUX_SESSION_NAME=$(tmux display-message -p '#S')
 
-if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
-  exit 0
-fi
+# Check if enabled
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_datetime 2>/dev/null)
+[[ ${ENABLED} -ne 1 ]] && exit 0
 
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
-
-# Grab global variable for showing datetime widget, only hide if explicitly disabled
-SHOW_DATETIME=$(tmux show-option -gv @tokyo-night-tmux_show_datetime 2>/dev/null)
-"$MINIMAL_SESSION_NAME $TMUX_SESSION_NAME"
-c
-if [[ $SHOW_DATETIME == "0" ]]; then
-  exit 0
-fi
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $CURRENT_DIR/themes.sh

--- a/src/datetime-widget.sh
+++ b/src/datetime-widget.sh
@@ -62,7 +62,7 @@ if [[ $date_string && $time_string ]]; then
   separator="❬ "
 fi
 
-date_string="$(date +$date_string)"
-time_string="$(date +$time_string)"
+date_string="$(date +"$date_string")"
+time_string="$(date +"$time_string")"
 
 echo "$RESET#[fg=${THEME[foreground]},bg=${THEME[bblack]}] $date_string $separator$time_string "

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
 
 SHOW_NETSPEED=$(tmux show-option -gv @tokyo-night-tmux_show_git)
 if [ "$SHOW_NETSPEED" == "0" ]; then

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
-# Verify if the current session is the minimal session
-MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session 2>/dev/null)
-TMUX_SESSION_NAME=$(tmux display-message -p '#S')
 
-if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
-  exit 0
-fi
-
-SHOW_NETSPEED=$(tmux show-option -gv @tokyo-night-tmux_show_git)
-if [ "$SHOW_NETSPEED" == "0" ]; then
-  exit 0
-fi
+# Check if enabled
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_git)
+[[ ${ENABLED} -ne 1 ]] && exit 0
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/../lib/coreutils-compat.sh"

--- a/src/git-status.sh
+++ b/src/git-status.sh
@@ -42,7 +42,7 @@ if [[ $STATUS -ne 0 ]]; then
   SYNC_MODE=1
 fi
 
-UNTRACKED_COUNT="$(git ls-files --other --directory --exclude-standard | wc -l | bc)"
+UNTRACKED_COUNT="$(git ls-files --other --exclude-standard | wc -l | bc)"
 
 if [[ $CHANGED_COUNT -gt 0 ]]; then
   STATUS_CHANGED="${RESET}#[fg=${THEME[yellow]},bg=${THEME[background]},bold] ${CHANGED_COUNT} "

--- a/src/hostname-widget.sh
+++ b/src/hostname-widget.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Imports
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+. "${ROOT_DIR}/lib/coreutils-compat.sh"
+
+# Check if enabled
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_hostname 2>/dev/null)
+[[ ${ENABLED} -ne 1 ]] && exit 0
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source $CURRENT_DIR/themes.sh
+
+hostname=$(hostnamectl hostname)
+ACCENT_COLOR="${THEME[black]}"
+
+echo "#[nodim,fg=$ACCENT_COLOR]@${hostname}"

--- a/src/hostname-widget.sh
+++ b/src/hostname-widget.sh
@@ -11,7 +11,15 @@ ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_hostname 2>/dev/null)
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $CURRENT_DIR/themes.sh
 
-hostname=$(hostnamectl hostname)
+if command -v hostnamectl >/dev/null 2>&1; then
+  hostname=$(hostnamectl hostname)
+elif command -v scutil >/dev/null 2>&1; then
+  hostname=$(scutil --get LocalHostName)
+elif command -v hostname >/dev/null 2>&1; then
+  hostname=$(hostname)
+else
+  hostname="unknown-host"
+fi
 ACCENT_COLOR="${THEME[black]}"
 
 echo "#[nodim,fg=$ACCENT_COLOR]@${hostname}"

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
+
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
@@ -28,12 +36,12 @@ fi
 
 # playerctl
 if command -v playerctl >/dev/null; then
-  PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}}" | grep -m1 "Playing")
+  PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}};{{playerName}}" | grep -m1 "Playing")
   STATUS="playing"
 
   # There is no playing media, check for paused media
   if [ -z "$PLAYER_STATUS" ]; then
-    PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}}" | grep -m1 "Paused")
+    PLAYER_STATUS=$(playerctl -a metadata --format "{{status}};{{mpris:length}};{{position}};{{title}};{{playerName}}" | grep -m1 "Paused")
     STATUS="paused"
   fi
 

--- a/src/music-tmux-statusbar.sh
+++ b/src/music-tmux-statusbar.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/env bash
 
-# Verify if the current session is the minimal session
-MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
-TMUX_SESSION_NAME=$(tmux display-message -p '#S')
-
-if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
-  exit 0
-fi
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_music)
+[[ ${ENABLED} -ne 1 ]] && exit 0
 
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
-
-# Check the global value
-SHOW_MUSIC=$(tmux show-option -gv @tokyo-night-tmux_show_music)
-
-if [ "$SHOW_MUSIC" != "1" ]; then
-  exit 0
-fi
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $CURRENT_DIR/themes.sh
@@ -58,8 +46,8 @@ if command -v playerctl >/dev/null; then
     POSITION=0
   fi
 
-# nowplaying-cli
-elif command -v nowplaying-cli >/dev/null; then
+  # nowplaying-cli
+elif command -v nowplaying-cli >/dev/null && { [[ $OSTYPE != "darwin"* ]] || { [[ $OSTYPE == "darwin"* ]] && [ "$(sw_vers -productVersion | cut -d. -f1)" -lt 15 ]; }; }; then
   NPCLI_PROPERTIES=(title duration elapsedTime playbackRate isAlwaysLive)
   mapfile -t NPCLI_OUTPUT < <(nowplaying-cli get "${NPCLI_PROPERTIES[@]}")
   declare -A NPCLI_VALUES
@@ -80,20 +68,30 @@ elif command -v nowplaying-cli >/dev/null; then
   else
     DURATION=$(printf "%.0f" "${NPCLI_VALUES[duration]}")
     POSITION=$(printf "%.0f" "${NPCLI_VALUES[elapsedTime]}")
-
-    # fix for the bug in nowplaying-cli.
-    # See https://github.com/janoamaral/tokyo-night-tmux/issues/107#issuecomment-2576211115
-    if [[ $OSTYPE == "darwin"* ]]; then
-      if [ $STATUS == "playing" ]; then
-        echo "$POSITION" >/tmp/last_position
-      fi
-
-      if [ "$STATUS" = "paused" ]; then
-        POSITION=$(cat /tmp/last_position)
-      fi
-    fi
-
   fi
+elif command -v media-control >/dev/null; then
+  MDC_PROPERTIES=(title duration elapsedTimeNow playing)
+  mapfile -t MDC_OUTPUT < <(
+    media_json=$(media-control get --now)
+    for field in "${MDC_PROPERTIES[@]}"; do
+      echo "$media_json" | jq -r --arg f "$field" '.[$f] // ""'
+    done
+  )
+  declare -A MDC_VALUES
+  for ((i = 0; i < ${#MDC_PROPERTIES[@]}; i++)); do
+    # Handle null values
+    [ "${MDC_OUTPUT[$i]}" = "null" ] && MDC_OUTPUT[$i]=""
+    MDC_VALUES[${MDC_PROPERTIES[$i]}]="${MDC_OUTPUT[$i]}"
+  done
+  if [ "${MDC_VALUES[playing]}" = "true" ]; then
+    STATUS="playing"
+  else
+    STATUS="paused"
+  fi
+  TITLE="${MDC_VALUES[title]}"
+  DURATION=$(printf "%.0f" "${MDC_VALUES[duration]}")
+  POSITION=$(printf "%.0f" "${MDC_VALUES[elapsedTimeNow]}")
+
 fi
 
 # Calculate the progress bar for sane durations

--- a/src/os-icons.sh
+++ b/src/os-icons.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+OS_ICON=""
+if [[ $OSTYPE == "linux-gnu"* ]]; then
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+    ubuntu)
+      OS_ICON=" "
+      OS_COLOR="#E95420"
+      ;;
+    fedora)
+      OS_ICON=" "
+      ;;
+    arch)
+      OS_ICON=" "
+      OS_COLOR="#1793D1"
+      ;;
+    debian)
+      OS_ICON=" "
+      ;;
+    centos)
+      OS_ICON=" "
+      ;;
+    manjaro)
+      OS_ICON=" "
+      ;;
+    alpine)
+      OS_ICON=" "
+      ;;
+    kali)
+      OS_ICON=" "
+      ;;
+    freebsd)
+      OS_ICON=" "
+      ;;
+    opensuse)
+      OS_ICON=" "
+      ;;
+    openbsd)
+      OS_ICON=" "
+      ;;
+    *)
+      OS_ICON=" "
+      ;;
+    esac
+  else
+    OS_ICON=" "
+  fi
+elif [[ $OSTYPE == "darwin"* ]]; then
+  OS_ICON=" "
+elif [[ $OSTYPE == "cygwin" || $OSTYPE == "msys" || $OSTYPE == "win32" ]]; then
+  OS_ICON=" "
+else
+  OS_ICON=" "
+fi
+
+echo "$OS_ICON"

--- a/src/path-widget.sh
+++ b/src/path-widget.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 
+# check if enabled
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_path 2>/dev/null)
+[[ ${ENABLED} -ne 1 ]] && exit 0
+
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
 
-# get value from tmux config
-SHOW_PATH=$(tmux show-option -gv @tokyo-night-tmux_show_path 2>/dev/null)
 PATH_FORMAT=$(tmux show-option -gv @tokyo-night-tmux_path_format 2>/dev/null) # full | relative
 RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
-
-# check if not enabled
-if [ "${SHOW_PATH}" != "1" ]; then
-  exit 0
-fi
 
 current_path="${1}"
 default_path_format="relative"

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -1,16 +1,7 @@
 #!/usr/bin/env bash
-# Verify if the current session is the minimal session
-MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
-TMUX_SESSION_NAME=$(tmux display-message -p '#S')
 
-if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
-  exit 0
-fi
-
-SHOW_WIDGET=$(tmux show-option -gv @tokyo-night-tmux_show_wbg)
-if [ "$SHOW_WIDGET" == "0" ]; then
-  exit 0
-fi
+ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_wbg)
+[[ ${ENABLED} -ne 1 ]] && exit 0
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/../lib/coreutils-compat.sh"

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Verify if the current session is the minimal session
+MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
+TMUX_SESSION_NAME=$(tmux display-message -p '#S')
+
+if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+  exit 0
+fi
+
 SHOW_WIDGET=$(tmux show-option -gv @tokyo-night-tmux_show_wbg)
 if [ "$SHOW_WIDGET" == "0" ]; then
   exit 0

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -18,7 +18,7 @@ source "$CURRENT_DIR/themes.sh"
 
 cd "$1" || exit 1
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-PROVIDER=$(git config remote.origin.url | awk -F '@|:' '{print $2}')
+PROVIDER=$(git config remote.origin.url | sed 's|https://||' | sed 's|git@||' | awk -F'[:/]' '{print $1}')
 
 PROVIDER_ICON=""
 

--- a/src/wb-git-status.sh
+++ b/src/wb-git-status.sh
@@ -3,7 +3,7 @@
 MINIMAL_SESSION_NAME=$(tmux show-option -gv @tokyo-night-tmux_minimal_session)
 TMUX_SESSION_NAME=$(tmux display-message -p '#S')
 
-if [ "$MINIMAL_SESSION_NAME" = $TMUX_SESSION_NAME ]; then
+if [ "$MINIMAL_SESSION_NAME" = "$TMUX_SESSION_NAME" ]; then
   exit 0
 fi
 

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -19,8 +19,8 @@ RESET="#[fg=${THEME[foreground]},bg=${THEME[background]},nobold,noitalics,nounde
 # Highlight colors
 tmux set -g mode-style "fg=${THEME[bgreen]},bg=${THEME[bblack]}"
 
-tmux set -g message-style "bg=${THEME[blue]},fg=${THEME[background]}"
-tmux set -g message-command-style "fg=${THEME[white]},bg=${THEME[black]}"
+tmux set -g message-style "bg=${THEME[blue]},fg=${THEME[bblack]}"
+tmux set -g message-command-style "fg=${THEME[blue]},bg=${THEME[bblack]}"
 
 tmux set -g pane-border-style "fg=${THEME[bblack]}"
 tmux set -g pane-active-border-style "fg=${THEME[blue]}"
@@ -72,9 +72,9 @@ tmux set -g status-left "#[fg=${THEME[bblack]},bg=${THEME[blue]},bold] #{?client
 
 #+--- Windows ---+
 # Focus
-tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[bblack]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,$active_terminal_icon $window_space}#[fg=${THEME[foreground]},bold,nodim]$window_number#W#[nobold]#{?window_zoomed_flag, $zoom_number, $custom_pane}#{?window_last_flag, , }"
+tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[bblack]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,  }#[fg=${THEME[foreground]},bold,nodim]$window_number#W#[nobold]#{?window_zoomed_flag, $zoom_number, $custom_pane}#{?window_last_flag, , }"
 # Unfocused
-tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,$terminal_icon $window_space}${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
+tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,  }${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
 
 #+--- Bars RIGHT ---+
 tmux set -g status-right "$battery_status$current_path$cmus_status$netspeed$git_status$wb_git_status$date_and_time"

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -27,6 +27,7 @@ tmux set -g pane-active-border-style "fg=${THEME[blue]}"
 tmux set -g pane-border-status off
 
 tmux set -g status-style bg="${THEME[background]}"
+tmux set -g popup-border-style "fg=${THEME[blue]}"
 
 TMUX_VARS="$(tmux show -g)"
 
@@ -60,7 +61,7 @@ wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I $window_id_style)"
 custom_pane="#($SCRIPTS_PATH/custom-number.sh #P $pane_id_style)"
 zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
-date_and_time="$($SCRIPTS_PATH/datetime-widget.sh)"
+date_and_time="#($SCRIPTS_PATH/datetime-widget.sh)"
 current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
 hostname="#($SCRIPTS_PATH/hostname-widget.sh)"


### PR DESCRIPTION
This pull request introduces several improvements and new features to the tmux Tokyo Night theme, focusing on better widget enablement logic, the addition of new widgets, enhancements to existing widgets, and various usability and visual tweaks.

**Widget Enablement and Consistency:**

* Refactored all widget scripts (such as `battery-widget.sh`, `datetime-widget.sh`, `git-status.sh`, `music-tmux-statusbar.sh`, `path-widget.sh`, `wb-git-status.sh`, and the new `hostname-widget.sh`) to use a consistent and more robust approach for checking if each widget is enabled via tmux options, exiting early if not enabled. [[1]](diffhunk://#diff-352e9772f6a89258af4496c31b403df5be3c9628806bb9dcdf1e1703afeb5d7cR3-L12) [[2]](diffhunk://#diff-5ae9500f90304857feed35cb345d17e981c633247b106b9c226c5bf77c1d7852R3-L12) [[3]](diffhunk://#diff-13c9e23e33fa7ab1fc1def8e003943bcdcd8904a265ecc2924bb57c4db250138L3-R5) [[4]](diffhunk://#diff-26f1237bbff23b80065dcfa314b2a7926dfbda915894124a66e4e24c347978bdR3-L13) [[5]](diffhunk://#diff-cf78b94bc700bd6512649012ecc2d34bcc0defdcc750ea16de688e76aae82950R3-L16) [[6]](diffhunk://#diff-c0218a72d043e352a2fcb7e91e179702ec4a5f5412a72c2d705685cc9365bbb6L2-R12) [[7]](diffhunk://#diff-d0e69f5ec55bd06990c4e1bde9fbf7b683daac9083196227eeb4fe017d360e44R1-R25)

**New Features and Widgets:**

* Added a new Hostname Widget (`hostname-widget.sh`) to display the current host's name in the status bar, with support for different platforms and fallback logic.
* Introduced an OS Icons script (`os-icons.sh`) to provide OS-specific icons for use in the status bar.
* Documented and improved the Web-based Git Widget, including setup instructions and support for both SSH and HTTPS remotes.

**Enhancements to Existing Widgets:**

* Improved the music status widget (`music-tmux-statusbar.sh`):
  - Now supports `media-control` as a backend in addition to `playerctl` and `nowplaying-cli`.
  - Enhanced compatibility logic for `nowplaying-cli` on macOS and Linux.
  - Updated the playerctl format string to include the player name. [[1]](diffhunk://#diff-26f1237bbff23b80065dcfa314b2a7926dfbda915894124a66e4e24c347978bdL31-R32) [[2]](diffhunk://#diff-26f1237bbff23b80065dcfa314b2a7926dfbda915894124a66e4e24c347978bdL54-R50) [[3]](diffhunk://#diff-26f1237bbff23b80065dcfa314b2a7926dfbda915894124a66e4e24c347978bdL75-L89)
* Improved the date and time widget to ensure correct formatting and output.
* Improved the git status widget to correctly handle untracked files and remote URL parsing. [[1]](diffhunk://#diff-13c9e23e33fa7ab1fc1def8e003943bcdcd8904a265ecc2924bb57c4db250138L38-R37) [[2]](diffhunk://#diff-c0218a72d043e352a2fcb7e91e179702ec4a5f5412a72c2d705685cc9365bbb6L2-R12)

**Visual and Usability Tweaks:**

* Adjusted tmux message and popup border styles for better visual consistency.
* Updated window status formatting to use a consistent terminal icon.
* Fixed the invocation of the datetime widget in the tmux config.

**Documentation:**

* Updated `README.md` to document the new Web-based Git Widget and clarify usage instructions.

These changes collectively improve the configurability, extensibility, and user experience of the tmux Tokyo Night theme.
