### PR TITLE
fix: align color palettes with folke/tokyonight.nvim

### DIFF
--- a/lib/coreutils-compat.sh
+++ b/lib/coreutils-compat.sh
@@ -2,21 +2,35 @@
 
 # Compatibility functions for macOS
 if [[ "$(uname)" == "Darwin" ]]; then
-  HOMEBREW_PREFIX="$(brew --prefix)"
-  # Use GNU coreutils if available
-  if [ -d "$HOMEBREW_PREFIX/opt/coreutils" ]; then
-    export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
+  HOMEBREW_PREFIX="$(brew --prefix 2>/dev/null)"
+  if [[ -z "$HOMEBREW_PREFIX" ]]; then
+    # Fallback to common Homebrew locations
+    if [[ -d "/opt/homebrew" ]]; then
+      HOMEBREW_PREFIX="/opt/homebrew"
+    elif [[ -d "/usr/local" ]]; then
+      HOMEBREW_PREFIX="/usr/local"
+    fi
   fi
-  # Use GNU awk if available
-  if [ -d "$HOMEBREW_PREFIX/opt/gawk" ]; then
-    export PATH="$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$PATH"
-  fi
-  # Use GNU sed if available
-  if [ -d "$HOMEBREW_PREFIX/opt/gsed" ]; then
-    export PATH="$HOMEBREW_PREFIX/opt/gsed/libexec/gnubin:$PATH"
-  fi
-  # Use Homebrew bc if available
-  if [ -d "$HOMEBREW_PREFIX/opt/bc" ]; then
-    export PATH="$HOMEBREW_PREFIX/opt/bc/bin:$PATH"
+  if [[ -n "$HOMEBREW_PREFIX" ]]; then
+    # Use Homebrew bash (required for associative arrays / bash 4+)
+    if [[ -d "$HOMEBREW_PREFIX/opt/bash" ]]; then
+      export PATH="$HOMEBREW_PREFIX/opt/bash/bin:$PATH"
+    fi
+    # Use GNU coreutils if available
+    if [[ -d "$HOMEBREW_PREFIX/opt/coreutils" ]]; then
+      export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
+    fi
+    # Use GNU awk if available
+    if [[ -d "$HOMEBREW_PREFIX/opt/gawk" ]]; then
+      export PATH="$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$PATH"
+    fi
+    # Use GNU sed if available
+    if [[ -d "$HOMEBREW_PREFIX/opt/gsed" ]]; then
+      export PATH="$HOMEBREW_PREFIX/opt/gsed/libexec/gnubin:$PATH"
+    fi
+    # Use Homebrew bc if available
+    if [[ -d "$HOMEBREW_PREFIX/opt/bc" ]]; then
+      export PATH="$HOMEBREW_PREFIX/opt/bc/bin:$PATH"
+    fi
   fi
 fi

--- a/src/battery-widget.sh
+++ b/src/battery-widget.sh
@@ -7,11 +7,11 @@ ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_battery_widget 2>/dev/null
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
+source "${ROOT_DIR}/src/themes.sh"
 
 # Get values from tmux config or set defaults
 BATTERY_NAME=$(tmux show-option -gv @tokyo-night-tmux_battery_name 2>/dev/null)
 BATTERY_LOW=$(tmux show-option -gv @tokyo-night-tmux_battery_low_threshold 2>/dev/null)
-RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 
 DISCHARGING_ICONS=("󰁺" "󰁻" "󰁼" "󰁽" "󰁾" "󰁿" "󰂀" "󰂁" "󰂂" "󰁹")
 CHARGING_ICONS=("󰢜" "󰂆" "󰂇" "󰂈" "󰢝" "󰂉" "󰢞" "󰂊" "󰂋" "󰂅")
@@ -111,11 +111,11 @@ esac
 
 # Set color based on battery percentage
 if [[ $BATTERY_PERCENTAGE -lt $BATTERY_LOW ]]; then
-  color="#[fg=red,bg=default,bold]"
+  color="#[fg=${THEME[red]},bg=default,bold]"
 elif [[ $BATTERY_PERCENTAGE -ge 100 ]]; then
-  color="#[fg=green,bg=default]"
+  color="#[fg=${THEME[green]},bg=default]"
 else
-  color="#[fg=yellow,bg=default]"
+  color="#[fg=${THEME[yellow]},bg=default]"
 fi
 
 # Print the battery status with some extra spaces for padding

--- a/src/cmus-tmux-statusbar.sh
+++ b/src/cmus-tmux-statusbar.sh
@@ -3,12 +3,13 @@
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
+source "${ROOT_DIR}/src/themes.sh"
 
-ACCENT_COLOR="#7aa2f7"
-SECONDARY_COLOR="#24283B"
-BG_COLOR="#1F2335"
-BG_BAR="#15161e"
-TIME_COLOR="#414868"
+ACCENT_COLOR="${THEME[blue]}"
+SECONDARY_COLOR="${THEME[background]}"
+BG_COLOR="${THEME[background]}"
+BG_BAR="${THEME[background]}"
+TIME_COLOR="${THEME[black]}"
 
 if [[ $1 =~ ^[[:digit:]]+$ ]]; then
   MAX_TITLE_WIDTH=20
@@ -34,14 +35,14 @@ if cmus-remote -Q >/dev/null 2>/dev/null; then
   TIME="[$P_MIN:$P_SEC / $D_MIN:$D_SEC]"
 
   if [ "$D_SEC" = "-1" ]; then
-    TIME="[ $P_MIN:$P_SEC]"
+    TIME="[ $P_MIN:$P_SEC]"
   fi
 
   if [ -n "$TITLE" ]; then
     if [ "$STATUS" = "playing" ]; then
-      PLAY_STATE="$OUTPUT"
+      PLAY_STATE="$OUTPUT"
     else
-      PLAY_STATE="$OUTPUT"
+      PLAY_STATE="$OUTPUT"
     fi
     OUTPUT="$PLAY_STATE $TITLE"
 

--- a/src/path-widget.sh
+++ b/src/path-widget.sh
@@ -7,9 +7,9 @@ ENABLED=$(tmux show-option -gv @tokyo-night-tmux_show_path 2>/dev/null)
 # Imports
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 . "${ROOT_DIR}/lib/coreutils-compat.sh"
+source "${ROOT_DIR}/src/themes.sh"
 
 PATH_FORMAT=$(tmux show-option -gv @tokyo-night-tmux_path_format 2>/dev/null) # full | relative
-RESET="#[fg=brightwhite,bg=#15161e,nobold,noitalics,nounderscore,nodim]"
 
 current_path="${1}"
 default_path_format="relative"
@@ -20,4 +20,4 @@ if [[ ${PATH_FORMAT} == "relative" ]]; then
   current_path="$(echo ${current_path} | sed 's#'"$HOME"'#~#g')"
 fi
 
-echo "#[fg=blue,bg=default]░  ${RESET}#[bg=default]${current_path} "
+echo "#[fg=${THEME[blue]},bg=default]░  ${RESET}#[bg=default]${current_path} "

--- a/src/themes.sh
+++ b/src/themes.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Color palettes from folke/tokyonight.nvim
+# https://github.com/folke/tokyonight.nvim
+
 SELECTED_THEME="$(tmux show-option -gv @tokyo-night-tmux_theme)"
 TRANSPARENT_THEME="$(tmux show-option -gv @tokyo-night-tmux_transparent)"
 
@@ -7,72 +10,96 @@ case $SELECTED_THEME in
 "storm")
   declare -A THEME=(
     ["background"]="#24283b"
-    ["foreground"]="#a9b1d6"
+    ["foreground"]="#c0caf5"
     ["black"]="#414868"
     ["blue"]="#7aa2f7"
     ["cyan"]="#7dcfff"
-    ["green"]="#73daca"
+    ["green"]="#9ece6a"
     ["magenta"]="#bb9af7"
     ["red"]="#f7768e"
     ["white"]="#a9b1d6"
     ["yellow"]="#e0af68"
 
-    ["bblack"]="#414868"
+    ["bblack"]="#292e42"
     ["bblue"]="#7aa2f7"
     ["bcyan"]="#7dcfff"
-    ["bgreen"]="#41a6b5"
+    ["bgreen"]="#73daca"
     ["bmagenta"]="#bb9af7"
-    ["bred"]="#f7768e"
-    ["bwhite"]="#787c99"
+    ["bred"]="#ff9e64"
+    ["bwhite"]="#565f89"
     ["byellow"]="#e0af68"
+  )
+  ;;
+
+"moon")
+  declare -A THEME=(
+    ["background"]="#222436"
+    ["foreground"]="#c8d3f5"
+    ["black"]="#444a73"
+    ["blue"]="#82aaff"
+    ["cyan"]="#86e1fc"
+    ["green"]="#c3e88d"
+    ["magenta"]="#c099ff"
+    ["red"]="#ff757f"
+    ["white"]="#828bb8"
+    ["yellow"]="#ffc777"
+
+    ["bblack"]="#2f334d"
+    ["bblue"]="#82aaff"
+    ["bcyan"]="#86e1fc"
+    ["bgreen"]="#4fd6be"
+    ["bmagenta"]="#c099ff"
+    ["bred"]="#ff966c"
+    ["bwhite"]="#636da6"
+    ["byellow"]="#ffc777"
   )
   ;;
 
 "day")
   declare -A THEME=(
-    ["background"]="#d5d6db"
-    ["foreground"]="#343b58"
-    ["black"]="#0f0f14"
-    ["blue"]="#34548a"
-    ["cyan"]="#0f4b6e"
-    ["green"]="#33635c"
-    ["magenta"]="#5a4a78"
-    ["red"]="#8c4351"
-    ["white"]="#343b58"
-    ["yellow"]="#8f5e15"
+    ["background"]="#e1e2e7"
+    ["foreground"]="#3760bf"
+    ["black"]="#a1a6c5"
+    ["blue"]="#2e7de9"
+    ["cyan"]="#007197"
+    ["green"]="#587539"
+    ["magenta"]="#9854f1"
+    ["red"]="#f52a65"
+    ["white"]="#6172b0"
+    ["yellow"]="#8c6c3e"
 
-    ["bblack"]="#9699a3"
-    ["bblue"]="#34548a"
-    ["bcyan"]="#0f4b6e"
-    ["bgreen"]="#33635c"
-    ["bmagenta"]="#5a4a78"
-    ["bred"]="#8c4351"
-    ["bwhite"]="#343b58"
-    ["byellow"]="#8f5815"
+    ["bblack"]="#c4c8da"
+    ["bblue"]="#2e7de9"
+    ["bcyan"]="#007197"
+    ["bgreen"]="#387068"
+    ["bmagenta"]="#9854f1"
+    ["bred"]="#b15c00"
+    ["bwhite"]="#848cb5"
+    ["byellow"]="#8c6c3e"
   )
   ;;
 
 *)
   # Default to night theme
   declare -A THEME=(
-    ["background"]="#1A1B26"
-    ["foreground"]="#a9b1d6"
+    ["background"]="#1a1b26"
+    ["foreground"]="#c0caf5"
     ["black"]="#414868"
     ["blue"]="#7aa2f7"
     ["cyan"]="#7dcfff"
-    ["green"]="#73daca"
+    ["green"]="#9ece6a"
     ["magenta"]="#bb9af7"
     ["red"]="#f7768e"
-    ["white"]="#c0caf5"
+    ["white"]="#a9b1d6"
     ["yellow"]="#e0af68"
 
-    ["bblack"]="#2A2F41"
+    ["bblack"]="#292e42"
     ["bblue"]="#7aa2f7"
     ["bcyan"]="#7dcfff"
-    ["bgreen"]="#41a6b5"
+    ["bgreen"]="#73daca"
     ["bmagenta"]="#bb9af7"
     ["bred"]="#ff9e64"
-    ["bwhite"]="#787c99"
+    ["bwhite"]="#565f89"
     ["byellow"]="#e0af68"
   )
   ;;

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -10,6 +10,22 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_PATH="$CURRENT_DIR/src"
 
+# On macOS, ensure Homebrew bin is in tmux's PATH so child scripts
+# spawned by tmux use bash 4+ (required for associative arrays)
+if [[ "$(uname)" == "Darwin" ]]; then
+  HOMEBREW_PREFIX="$(brew --prefix 2>/dev/null)"
+  if [[ -z "$HOMEBREW_PREFIX" ]]; then
+    [[ -d "/opt/homebrew" ]] && HOMEBREW_PREFIX="/opt/homebrew"
+    [[ -d "/usr/local/Homebrew" ]] && HOMEBREW_PREFIX="/usr/local"
+  fi
+  if [[ -n "$HOMEBREW_PREFIX" ]]; then
+    CURRENT_PATH="$(tmux show-environment -g PATH 2>/dev/null | sed 's/^PATH=//' || echo "$PATH")"
+    if [[ "$CURRENT_PATH" != *"$HOMEBREW_PREFIX/bin"* ]]; then
+      tmux set-environment -g PATH "$HOMEBREW_PREFIX/bin:$CURRENT_PATH"
+    fi
+  fi
+fi
+
 source $SCRIPTS_PATH/themes.sh
 
 tmux set -g status-left-length 80


### PR DESCRIPTION
## Summary

- **Fix night/storm color palettes** to match [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim) official colors:
  - `green`: `#73daca` → `#9ece6a` (was using `green1` instead of `green`)
  - `foreground`: `#a9b1d6` → `#c0caf5` (was using `fg_dark` instead of `fg`)
  - `bblack`: corrected to `#292e42` (`bg_highlight`)
  - `bwhite`: corrected to `#565f89` (`comment`)
  - Storm `bred`/`bblack` were duplicates of base `red`/`black` — now differentiated
- **Fix day theme**: nearly all colors were incorrect vs folke's palette (bg, fg, all accents)
- **Add moon theme variant** — was completely missing from the plugin
- **Remove hardcoded hex colors** in `path-widget.sh`, `battery-widget.sh`, and `cmus-tmux-statusbar.sh` — now use `THEME[]` references for proper multi-theme support
- **Add Homebrew bash support on macOS**: sets tmux environment `PATH` to include Homebrew's `bin`, ensuring child scripts use bash 4+ (required for associative arrays)

## Color reference

All colors sourced from `folke/tokyonight.nvim`:
- `lua/tokyonight/colors/{night,storm,moon}.lua`
- `extras/lua/tokyonight_{night,storm,moon,day}.lua`

## Test plan

- [ ] Verify night theme renders correctly
- [ ] Verify storm theme renders correctly
- [ ] Verify moon theme renders correctly (`set -g @tokyo-night-tmux_theme moon`)
- [ ] Verify day theme renders correctly
- [ ] Verify battery widget colors follow theme
- [ ] Verify path widget colors follow theme
- [ ] Verify cmus widget colors follow theme
- [ ] Test on macOS with Homebrew bash
- [ ] Test transparent mode still works