### PR TITLE
fix(battery): handle statuses with spaces like "Not charging"

### DIFF
--- a/src/battery-widget.sh
+++ b/src/battery-widget.sh
@@ -82,11 +82,11 @@ get_battery_stats() {
     ;;
   esac
 
-  echo "$battery_status $battery_percentage"
+  printf '%s\t%s\n' "$battery_status" "$battery_percentage"
 }
 
 # Fetch the battery status and percentage
-read -r BATTERY_STATUS BATTERY_PERCENTAGE < <(get_battery_stats "$BATTERY_NAME")
+IFS=$'\t' read -r BATTERY_STATUS BATTERY_PERCENTAGE < <(get_battery_stats "$BATTERY_NAME")
 
 # Ensure percentage is a number
 if ! [[ $BATTERY_PERCENTAGE =~ ^[0-9]+$ ]]; then
@@ -101,7 +101,7 @@ case "$BATTERY_STATUS" in
 "Discharging" | "discharging")
   ICON="${DISCHARGING_ICONS[$((BATTERY_PERCENTAGE / 10))]}"
   ;;
-"Full" | "charged" | "full" | "AC")
+"Full" | "charged" | "full" | "AC" | "Not charging")
   ICON="$NOT_CHARGING_ICON"
   ;;
 *)


### PR DESCRIPTION
## Major changes

None.

## Minor changes

None.

## Bug & security fixes

- [x] Fix the battery widget rendering `0%` with the no-battery icon whenever `/sys/class/power_supply/<bat>/status` is a multi-word value such as `Not charging` (common on ThinkPad charge-threshold firmware and ASUS battery-health modes). Stats are now tab-separated so multi-word statuses round-trip intact. Fixes #149.
- [x] Recognise `Not charging` alongside `Full` / `AC` as a non-charging state so the correct icon is displayed instead of the no-battery fallback.

## Additional information

### Root cause

`src/battery-widget.sh` emits stats as `"$status $percentage"` (space-separated) and reads them back with `read -r STATUS PERCENTAGE`. When the status contains whitespace (e.g. `Not charging`), `STATUS` becomes `Not`, `PERCENTAGE` becomes `charging 95`, the numeric regex check resets `PERCENTAGE` to `0`, and the status switch falls through to the default no-battery icon.

### Reproduction

On a Linux host with a charge-threshold set (so `/sys/class/power_supply/BAT0/status` reads `Not charging`):

```console
$ cat /sys/class/power_supply/BAT0/status
Not charging
$ cat /sys/class/power_supply/BAT0/capacity
95
$ bash src/battery-widget.sh
#[fg=red,bg=default,bold]░ 󱉝#[…] #[bg=default] 0%
```

After the fix:

```console
$ bash src/battery-widget.sh
#[fg=yellow,bg=default]░ 󰚥#[…] #[bg=default] 95%
```

### Test plan

- [x] `Not charging` / 95% → `󰚥` + `95%` (non-charging icon, yellow)
- [x] `Discharging` / 75% → discharging icon, yellow
- [x] `Charging` / 30% → charging icon
- [x] `Full` / 100% → non-charging icon, green
- [x] Missing battery path → widget exits silently (unchanged)