### PR TITLE
fix: quote pane_current_path so widgets work in paths with spaces

### DIFF
--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -56,13 +56,13 @@ window_space=$([[ $window_tidy == "0" ]] && echo " " || echo "")
 
 netspeed="#($SCRIPTS_PATH/netspeed.sh)"
 cmus_status="#($SCRIPTS_PATH/music-tmux-statusbar.sh)"
-git_status="#($SCRIPTS_PATH/git-status.sh #{pane_current_path})"
-wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
+git_status="#($SCRIPTS_PATH/git-status.sh #{q:pane_current_path})"
+wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{q:pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I $window_id_style)"
 custom_pane="#($SCRIPTS_PATH/custom-number.sh #P $pane_id_style)"
 zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
 date_and_time="#($SCRIPTS_PATH/datetime-widget.sh)"
-current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
+current_path="#($SCRIPTS_PATH/path-widget.sh #{q:pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
 hostname="#($SCRIPTS_PATH/hostname-widget.sh)"
 


### PR DESCRIPTION
## Problem

When `#{pane_current_path}` contains a space (e.g. `/Users/me/Projects/Foo Bar`), tmux substitutes it into the format string **unquoted**, so the widget scripts receive it as multiple positional arguments:

```
git-status.sh /Users/me/Projects/Foo Bar
              ^^^^^^^^^^^^^^^^^^^^^^^ ^^^
              $1                      $2
```

Each widget then runs `cd "$1" || exit 1` against an incomplete path, fails, and emits nothing — so `git-status`, `wb-git-status`, and the path widget silently disappear from the status bar for any user whose working directory has a space in its name.

## Repro

```sh
mkdir -p ~/"Foo Bar" && cd ~/"Foo Bar" && git init
tmux new -s repro
# status-right is missing the git widget and the path widget
```

## Fix

Wrap `#{pane_current_path}` with tmux's built-in `#{q:...}` quote modifier, which escapes the value into a single shell-safe argument. The widget scripts are unchanged — they already use `cd "$1"`, which now receives the full path as one arg.

Three call sites updated in `tokyo-night.tmux`:
- `git_status` → `git-status.sh`
- `wb_git_status` → `wb-git-status.sh`
- `current_path` → `path-widget.sh`

## Test plan

- [x] Repo at `/path/with spaces`: widgets render correctly (branch name, diff stats, path).
- [x] Repo at `/path/without_spaces`: no regression.
- [x] Non-git directory: `git-status.sh` still exits silently as before.

Tested on tmux 3.6a / macOS 14.