### PR TITLE
feat: add widget reordering via show_right_widgets option

### DIFF
--- a/lib/widget-reorder.sh
+++ b/lib/widget-reorder.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Build a status string from a comma-separated widget list option
+# Usage: build_widget_string <option_suffix>
+#   e.g. build_widget_string "show_right_widgets" reads @tokyo-night-tmux_show_right_widgets
+#
+# Known widget names are mapped to their predefined #() substitution strings.
+# Entries starting with #( or #{ are passed through verbatim (arbitrary commands/format vars).
+# Entries starting with #[ are passed through verbatim (tmux format attributes).
+# Unknown widget names are silently skipped.
+# Empty items in the list are silently skipped.
+function build_widget_string() {
+  local option_name="@tokyo-night-tmux_$1"
+  local list
+  list=$(echo "$TMUX_VARS" | grep "${option_name}" | sed 's/^[^ ]* //')
+  [[ -z $list ]] && return
+
+  local result=""
+  local saved_ifs="$IFS"
+  IFS=','
+  for item in $list; do
+    # Trim leading/trailing whitespace
+    item="$(echo "$item" | xargs)"
+    # Skip empty items
+    [[ -z $item ]] && continue
+    if [[ $item == "#("* ]] || [[ $item == "#{"* ]] || [[ $item == "#["* ]]; then
+      # Passthrough — user-supplied tmux command, format variable, or attribute
+      result+="$item"
+    else
+      case "$item" in
+      battery) result+="$battery_status" ;;
+      path) result+="$current_path" ;;
+      music) result+="$cmus_status" ;;
+      netspeed) result+="$netspeed" ;;
+      git) result+="$git_status" ;;
+      wbg) result+="$wb_git_status" ;;
+      datetime) result+="$date_and_time" ;;
+      hostname) result+="$hostname" ;;
+      esac
+    fi
+  done
+  IFS="$saved_ifs"
+  echo "$result"
+}

--- a/lib/widget-reorder.sh
+++ b/lib/widget-reorder.sh
@@ -19,8 +19,8 @@ function build_widget_string() {
   local saved_ifs="$IFS"
   IFS=','
   for item in $list; do
-    # Trim leading/trailing whitespace
-    item="$(echo "$item" | xargs)"
+    # Trim leading/trailing whitespace (preserve quoting/backslashes inside the item)
+    item="$(printf '%s' "$item" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
     # Skip empty items
     [[ -z $item ]] && continue
     if [[ $item == "#("* ]] || [[ $item == "#{"* ]] || [[ $item == "#["* ]]; then

--- a/test/widget-reorder.bats
+++ b/test/widget-reorder.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+# shellcheck source=lib/widget-reorder.sh
+source "${BATS_TEST_DIRNAME}/../lib/widget-reorder.sh"
+
+setup() {
+  # Mock TMUX_VARS as it would appear from "tmux show -g"
+  export TMUX_VARS="
+@tokyo-night-tmux_show_right_widgets path, git, netspeed
+@tokyo-night-tmux_window_id_style digital
+@tokyo-night-tmux_show_git 1
+"
+
+  # Mock widget #() substitution strings (same format as in tokyo-night.tmux)
+  export battery_status="#(${BATS_TEST_DIRNAME}/../src/battery-widget.sh)"
+  export current_path="#(${BATS_TEST_DIRNAME}/../src/path-widget.sh #{pane_current_path})"
+  export cmus_status="#(${BATS_TEST_DIRNAME}/../src/music-tmux-statusbar.sh)"
+  export netspeed="#(${BATS_TEST_DIRNAME}/../src/netspeed.sh)"
+  export git_status="#(${BATS_TEST_DIRNAME}/../src/git-status.sh #{pane_current_path})"
+  export wb_git_status="#(${BATS_TEST_DIRNAME}/../src/wb-git-status.sh #{pane_current_path} &)"
+  export date_and_time="#(${BATS_TEST_DIRNAME}/../src/datetime-widget.sh)"
+  export hostname="#(${BATS_TEST_DIRNAME}/../src/hostname-widget.sh)"
+}
+
+@test "build_widget_string returns empty for unset option" {
+  run build_widget_string "show_nonexistent"
+  [[ -z $output ]]
+}
+
+@test "build_widget_string returns single widget" {
+  # Override TMUX_VARS with a single-widget list
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets git"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "$git_status" ]]
+}
+
+@test "build_widget_string returns widgets in specified order" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets datetime, git, battery"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "${date_and_time}${git_status}${battery_status}" ]]
+}
+
+@test "build_widget_string trims whitespace around widget names" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets  path ,  netspeed  ,  hostname  "
+  run build_widget_string "show_right_widgets"
+  [[ $output == "${current_path}${netspeed}${hostname}" ]]
+}
+
+@test "build_widget_string passes through #() commands verbatim" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets #(~/.tmux/foo.sh arg1 arg2)"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "#(~/.tmux/foo.sh arg1 arg2)" ]]
+}
+
+@test "build_widget_string passes through #{ format vars verbatim" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets #{session_name}, #{pane_current_command}"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "#{session_name}#{pane_current_command}" ]]
+}
+
+@test "build_widget_string passes through #[ format attributes verbatim" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets #[fg=red]●, #[bold]text"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "#[fg=red]●#[bold]text" ]]
+}
+
+@test "build_widget_string mixes known widgets and passthrough entries" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets git, #(curl -s http://status), datetime"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "${git_status}#(curl -s http://status)${date_and_time}" ]]
+}
+
+@test "build_widget_string ignores unknown widget names silently" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets git, nonexistent_widget, datetime"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "${git_status}${date_and_time}" ]]
+}
+
+@test "build_widget_string handles empty list item gracefully" {
+  export TMUX_VARS="@tokyo-night-tmux_show_right_widgets git, , datetime"
+  run build_widget_string "show_right_widgets"
+  [[ $output == "${git_status}${date_and_time}" ]]
+}

--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -11,6 +11,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_PATH="$CURRENT_DIR/src"
 
 source $SCRIPTS_PATH/themes.sh
+source "$CURRENT_DIR/lib/widget-reorder.sh"
 
 tmux set -g status-left-length 80
 tmux set -g status-right-length 150
@@ -56,13 +57,13 @@ window_space=$([[ $window_tidy == "0" ]] && echo " " || echo "")
 
 netspeed="#($SCRIPTS_PATH/netspeed.sh)"
 cmus_status="#($SCRIPTS_PATH/music-tmux-statusbar.sh)"
-git_status="#($SCRIPTS_PATH/git-status.sh #{pane_current_path})"
-wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
+git_status="#($SCRIPTS_PATH/git-status.sh #{q:pane_current_path})"
+wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{q:pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I $window_id_style)"
 custom_pane="#($SCRIPTS_PATH/custom-number.sh #P $pane_id_style)"
 zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
 date_and_time="#($SCRIPTS_PATH/datetime-widget.sh)"
-current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
+current_path="#($SCRIPTS_PATH/path-widget.sh #{q:pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
 hostname="#($SCRIPTS_PATH/hostname-widget.sh)"
 
@@ -77,5 +78,10 @@ tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[
 tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,  }${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
 
 #+--- Bars RIGHT ---+
-tmux set -g status-right "$battery_status$current_path$cmus_status$netspeed$git_status$wb_git_status$date_and_time"
+RIGHT_WIDGETS=$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_show_right_widgets' | cut -d" " -f2)
+if [[ -n $RIGHT_WIDGETS ]]; then
+  tmux set -g status-right "$(build_widget_string "show_right_widgets")"
+else
+  tmux set -g status-right "$battery_status$current_path$cmus_status$netspeed$git_status$wb_git_status$date_and_time"
+fi
 tmux set -g window-status-separator ""


### PR DESCRIPTION
Closes #67

Adds @tokyo-night-tmux_show_right_widgets — a comma-separated list that controls which widgets appear in the status-right and their order.

Entries starting with #(, #{, or #[ are passed through verbatim, allowing arbitrary tmux commands, format variables, and attributes.

I chose to use comma separated list to allow for arbitary tmux commands, variables and attributes.

Also includes the path quoting fix (#{q:pane_current_path}) from PR #152 — shell-escapes pane paths so widgets don't break on paths with spaces or special characters.