### PR TITLE
feat: add zoom icon indicator

### DIFF
--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -37,6 +37,7 @@ default_zoom_id_style="dsquare"
 
 default_terminal_icon=""
 default_active_terminal_icon=""
+default_zoom_icon="󰊓"
 
 window_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_window_id_style' | cut -d" " -f2)"
 pane_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_pane_id_style' | cut -d" " -f2)"
@@ -44,12 +45,14 @@ zoom_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_zoom_id_style' | cu
 terminal_icon="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_terminal_icon' | cut -d" " -f2)"
 active_terminal_icon="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_active_terminal_icon' | cut -d" " -f2)"
 window_tidy="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_window_tidy_icons' | cut -d" " -f2)"
+zoom_icon="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_zoom_icon' | cut -d" " -f2)"
 
 window_id_style="${window_id_style:-$default_window_id_style}"
 pane_id_style="${pane_id_style:-$default_pane_id_style}"
 zoom_id_style="${zoom_id_style:-$default_zoom_id_style}"
 terminal_icon="${terminal_icon:-$default_terminal_icon}"
 active_terminal_icon="${active_terminal_icon:-$default_active_terminal_icon}"
+zoom_icon="${zoom_icon:-$default_zoom_icon}"
 window_space="${window_tidy:-0}"
 
 window_space=$([[ $window_tidy == "0" ]] && echo " " || echo "")
@@ -60,7 +63,11 @@ git_status="#($SCRIPTS_PATH/git-status.sh #{pane_current_path})"
 wb_git_status="#($SCRIPTS_PATH/wb-git-status.sh #{pane_current_path} &)"
 window_number="#($SCRIPTS_PATH/custom-number.sh #I $window_id_style)"
 custom_pane="#($SCRIPTS_PATH/custom-number.sh #P $pane_id_style)"
-zoom_number="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
+if [[ $zoom_id_style == "icon" ]]; then
+  zoom_indicator=$zoom_icon
+else
+  zoom_indicator="#($SCRIPTS_PATH/custom-number.sh #P $zoom_id_style)"
+fi
 date_and_time="#($SCRIPTS_PATH/datetime-widget.sh)"
 current_path="#($SCRIPTS_PATH/path-widget.sh #{pane_current_path})"
 battery_status="#($SCRIPTS_PATH/battery-widget.sh)"
@@ -72,9 +79,9 @@ tmux set -g status-left "#[fg=${THEME[bblack]},bg=${THEME[blue]},bold] #{?client
 
 #+--- Windows ---+
 # Focus
-tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[bblack]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,  }#[fg=${THEME[foreground]},bold,nodim]$window_number#W#[nobold]#{?window_zoomed_flag, $zoom_number, $custom_pane}#{?window_last_flag, , }"
+tmux set -g window-status-current-format "$RESET#[fg=${THEME[green]},bg=${THEME[bblack]}] #{?#{==:#{pane_current_command},ssh},󰣀 , }#[fg=${THEME[foreground]},bold,nodim]$window_number#W#[nobold]#{?window_zoomed_flag, $zoom_indicator , $custom_pane}#{?window_last_flag, , }"
 # Unfocused
-tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 ,  }${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_number, $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
+tmux set -g window-status-format "$RESET#[fg=${THEME[foreground]}] #{?#{==:#{pane_current_command},ssh},󰣀 , }${RESET}$window_number#W#[nobold,dim]#{?window_zoomed_flag, $zoom_indicator , $custom_pane}#[fg=${THEME[yellow]}]#{?window_last_flag,󰁯  , }"
 
 #+--- Bars RIGHT ---+
 tmux set -g status-right "$battery_status$current_path$cmus_status$netspeed$git_status$wb_git_status$date_and_time"

--- a/user_docs/customization.md
+++ b/user_docs/customization.md
@@ -73,7 +73,10 @@ When a pane is zoomed (`prefix` + `z`), the pane number in the status bar is ren
 
 ```bash
 set -g @tokyo-night-tmux_zoom_id_style dsquare
-```
+# or use a set icon instead
+set -g @tokyo-night-tmux_zoom_id_style icon
+# Set a custom icon
+set -g @tokyo-night-tmux_zoom_icon 
 
 ---
 


### PR DESCRIPTION
[x] Resolves #154 

Adds a new possible value `"icon"` to the var `zoom_id_style` as well as a new var `zoom_icon`.
Should the style be "icon", the indicator number is replaced with the set icon.
