### PR TITLE
feat: add option to change change background color of session name fo…

### DIFF
--- a/tokyo-night.tmux
+++ b/tokyo-night.tmux
@@ -37,6 +37,7 @@ default_zoom_id_style="dsquare"
 
 default_terminal_icon=""
 default_active_terminal_icon=""
+default_prefix_background_color="${THEME[blue]}"
 
 window_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_window_id_style' | cut -d" " -f2)"
 pane_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_pane_id_style' | cut -d" " -f2)"
@@ -44,6 +45,7 @@ zoom_id_style="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_zoom_id_style' | cu
 terminal_icon="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_terminal_icon' | cut -d" " -f2)"
 active_terminal_icon="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_active_terminal_icon' | cut -d" " -f2)"
 window_tidy="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_window_tidy_icons' | cut -d" " -f2)"
+prefix_active_color="$(echo "$TMUX_VARS" | grep '@tokyo-night-tmux_prefix_active_color' | cut -d" " -f2 | tr -d '""')"
 
 window_id_style="${window_id_style:-$default_window_id_style}"
 pane_id_style="${pane_id_style:-$default_pane_id_style}"
@@ -51,6 +53,7 @@ zoom_id_style="${zoom_id_style:-$default_zoom_id_style}"
 terminal_icon="${terminal_icon:-$default_terminal_icon}"
 active_terminal_icon="${active_terminal_icon:-$default_active_terminal_icon}"
 window_space="${window_tidy:-0}"
+prefix_active_color="${prefix_active_color:-$default_prefix_background_color}"
 
 window_space=$([[ $window_tidy == "0" ]] && echo " " || echo "")
 
@@ -68,7 +71,7 @@ hostname="#($SCRIPTS_PATH/hostname-widget.sh)"
 
 #+--- Bars LEFT ---+
 # Session name
-tmux set -g status-left "#[fg=${THEME[bblack]},bg=${THEME[blue]},bold] #{?client_prefix,󰠠 ,#[dim]󰤂 }#[bold,nodim]#S$hostname "
+tmux set -g status-left "#[fg=${THEME[bblack]},bg=${THEME[blue]},bold] #{?client_prefix,#[bg=${prefix_active_color}]󰠠 ,#[dim]󰤂 }#[bold,nodim]#S$hostname "
 
 #+--- Windows ---+
 # Focus

--- a/user_docs/customization.md
+++ b/user_docs/customization.md
@@ -64,6 +64,11 @@ Windows running an active `ssh` session automatically show the `󰣀` icon inste
 ## Prefix highlight
 
 When the tmux prefix key is active, the session name in the status bar changes its icon to `󰠠` to indicate prefix mode. This is built-in and requires no configuration.
+If you want to make active prefix key even more obvious, you can change the background color of the session name:
+
+```bash
+set -g @tokyo-night-tmux_prefix_active_color "#f7768e"
+```
 
 ---
 


### PR DESCRIPTION
closes #156 
Adds an option to set a custom color to the session name when the prefix key is active.

A potential issue with this implementation, is when a user tries this out and want to get back to the default behaviour, either he has to run `tmux set -ug @tokyo-night-tmux_prefix_active_color` or set the color to the default in his config `set -g @tokyo-night-tmux_prefix_active_color "#82aaff"` . 
If anyone has a good idea how to improve on that let me know. Otherwise I would just add this hint in the docs for user customization.
